### PR TITLE
Fix: Request Filters

### DIFF
--- a/cli/assign_server_virtual_network_operation.go
+++ b/cli/assign_server_virtual_network_operation.go
@@ -444,9 +444,9 @@ func registerAssignServerVirtualNetworkParamsBodyDataAttributesServerID(depth in
 
 	var serverIdFlagName = "server_id"
 
-	var serverIdFlagDefault int64
+	var serverIdFlagDefault string
 
-	_ = cmd.PersistentFlags().Int64(serverIdFlagName, serverIdFlagDefault, serverIdDescription)
+	_ = cmd.PersistentFlags().String(serverIdFlagName, serverIdFlagDefault, serverIdDescription)
 	cmd.MarkPersistentFlagRequired(serverIdFlagName)
 
 	return nil
@@ -461,9 +461,9 @@ func registerAssignServerVirtualNetworkParamsBodyDataAttributesVirtualNetworkID(
 
 	var virtualNetworkIdFlagName = "virtual_network_id"
 
-	var virtualNetworkIdFlagDefault int64
+	var virtualNetworkIdFlagDefault string
 
-	_ = cmd.PersistentFlags().Int64(virtualNetworkIdFlagName, virtualNetworkIdFlagDefault, virtualNetworkIdDescription)
+	_ = cmd.PersistentFlags().String(virtualNetworkIdFlagName, virtualNetworkIdFlagDefault, virtualNetworkIdDescription)
 	cmd.MarkPersistentFlagRequired(virtualNetworkIdFlagName)
 
 	return nil
@@ -497,11 +497,11 @@ func retrieveAssignServerVirtualNetworkParamsBodyDataAttributesServerIDFlags(dep
 	var serverIdFlagName = "server_id"
 	if cmd.Flags().Changed(serverIdFlagName) {
 
-		serverIdFlagValue, err := cmd.Flags().GetInt64(serverIdFlagName)
+		serverIdFlagValue, err := cmd.Flags().GetString(serverIdFlagName)
 		if err != nil {
 			return err, false
 		}
-		m.ServerID = &serverIdFlagValue
+		m.ServerID = serverIdFlagValue
 
 		retAdded = true
 	}
@@ -518,11 +518,11 @@ func retrieveAssignServerVirtualNetworkParamsBodyDataAttributesVirtualNetworkIDF
 	var virtualNetworkIdFlagName = "virtual_network_id"
 	if cmd.Flags().Changed(virtualNetworkIdFlagName) {
 
-		virtualNetworkIdFlagValue, err := cmd.Flags().GetInt64(virtualNetworkIdFlagName)
+		virtualNetworkIdFlagValue, err := cmd.Flags().GetString(virtualNetworkIdFlagName)
 		if err != nil {
 			return err, false
 		}
-		m.VirtualNetworkID = &virtualNetworkIdFlagValue
+		m.VirtualNetworkID = virtualNetworkIdFlagValue
 
 		retAdded = true
 	}

--- a/cli/get_bandwidth_plans_operation.go
+++ b/cli/get_bandwidth_plans_operation.go
@@ -96,9 +96,9 @@ func registerOperationPlansGetBandwidthPlansFilterIDParamFlags(cmdPrefix string,
 
 	var filterIdFlagName string
 	if cmdPrefix == "" {
-		filterIdFlagName = "filter[id]"
+		filterIdFlagName = "id"
 	} else {
-		filterIdFlagName = fmt.Sprintf("%v.filter[id]", cmdPrefix)
+		filterIdFlagName = fmt.Sprintf("%v.id", cmdPrefix)
 	}
 
 	var filterIdFlagDefault string
@@ -130,13 +130,13 @@ func retrieveOperationPlansGetBandwidthPlansAPIVersionFlag(m *plans.GetBandwidth
 }
 func retrieveOperationPlansGetBandwidthPlansFilterIDFlag(m *plans.GetBandwidthPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[id]") {
+	if cmd.Flags().Changed("id") {
 
 		var filterIdFlagName string
 		if cmdPrefix == "" {
-			filterIdFlagName = "filter[id]"
+			filterIdFlagName = "id"
 		} else {
-			filterIdFlagName = fmt.Sprintf("%v.filter[id]", cmdPrefix)
+			filterIdFlagName = fmt.Sprintf("%v.id", cmdPrefix)
 		}
 
 		filterIdFlagValue, err := cmd.Flags().GetString(filterIdFlagName)

--- a/cli/get_plans_operation.go
+++ b/cli/get_plans_operation.go
@@ -63,7 +63,13 @@ func runOperationPlansGetPlans(cmd *cobra.Command, args []string) error {
 	if err, _ := retrieveOperationPlansGetPlansFilterNameFlag(params, "", cmd); err != nil {
 		return err
 	}
-	if err, _ := retrieveOperationPlansGetPlansFilterRAMFlag(params, "", cmd); err != nil {
+	if err, _ := retrieveOperationPlansGetPlansFilterRAMEqlFlag(params, "", cmd); err != nil {
+		return err
+	}
+	if err, _ := retrieveOperationPlansGetPlansFilterRAMLteFlag(params, "", cmd); err != nil {
+		return err
+	}
+	if err, _ := retrieveOperationPlansGetPlansFilterRAMGteFlag(params, "", cmd); err != nil {
 		return err
 	}
 	if err, _ := retrieveOperationPlansGetPlansFilterSlugFlag(params, "", cmd); err != nil {
@@ -114,7 +120,13 @@ func registerOperationPlansGetPlansParamFlags(cmd *cobra.Command) error {
 	if err := registerOperationPlansGetPlansFilterNameParamFlags("", cmd); err != nil {
 		return err
 	}
-	if err := registerOperationPlansGetPlansFilterRAMParamFlags("", cmd); err != nil {
+	if err := registerOperationPlansGetPlansFilterRAMEqlParamFlags("", cmd); err != nil {
+		return err
+	}
+	if err := registerOperationPlansGetPlansFilterRAMLteParamFlags("", cmd); err != nil {
+		return err
+	}
+	if err := registerOperationPlansGetPlansFilterRAMGteParamFlags("", cmd); err != nil {
 		return err
 	}
 	if err := registerOperationPlansGetPlansFilterSlugParamFlags("", cmd); err != nil {
@@ -262,23 +274,54 @@ func registerOperationPlansGetPlansFilterNameParamFlags(cmdPrefix string, cmd *c
 
 	return nil
 }
-func registerOperationPlansGetPlansFilterRAMParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+func registerOperationPlansGetPlansFilterRAMEqlParamFlags(cmdPrefix string, cmd *cobra.Command) error {
 
-	filterRamDescription := `The ram size in Gigabytes to filter by, should be used with the following options:
-                              [eql] to filter for values equal to the provided value.
-                              [gte] to filter for values greater or equal to the provided value.
-                              [lte] to filter by values lower or equal to the provided value.`
+	filterRamEqlDescription := `Filter plans with RAM size (in GB) equals the provided value.`
 
-	var filterRamFlagName string
+	var filterRamEqlFlagName string
 	if cmdPrefix == "" {
-		filterRamFlagName = "ram"
+		filterRamEqlFlagName = "ram_eql"
 	} else {
-		filterRamFlagName = fmt.Sprintf("%v.ram", cmdPrefix)
+		filterRamEqlFlagName = fmt.Sprintf("%v.ram_eql", cmdPrefix)
 	}
 
-	var filterRamFlagDefault int64
+	var filterRamEqlFlagDefault int64
 
-	_ = cmd.PersistentFlags().Int64(filterRamFlagName, filterRamFlagDefault, filterRamDescription)
+	_ = cmd.PersistentFlags().Int64(filterRamEqlFlagName, filterRamEqlFlagDefault, filterRamEqlDescription)
+
+	return nil
+}
+func registerOperationPlansGetPlansFilterRAMGteParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+
+	filterRamGteDescription := `Filter plans with RAM size (in GB) greater than or equal the provided value.`
+
+	var filterRamGteFlagName string
+	if cmdPrefix == "" {
+		filterRamGteFlagName = "ram_gte"
+	} else {
+		filterRamGteFlagName = fmt.Sprintf("%v.ram_gte", cmdPrefix)
+	}
+
+	var filterRamGteFlagDefault int64
+
+	_ = cmd.PersistentFlags().Int64(filterRamGteFlagName, filterRamGteFlagDefault, filterRamGteDescription)
+
+	return nil
+}
+func registerOperationPlansGetPlansFilterRAMLteParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+
+	filterRamLteDescription := `Filter plans with RAM size (in GB) less than or equal the provided value.`
+
+	var filterRamLteFlagName string
+	if cmdPrefix == "" {
+		filterRamLteFlagName = "ram_lte"
+	} else {
+		filterRamLteFlagName = fmt.Sprintf("%v.ram_lte", cmdPrefix)
+	}
+
+	var filterRamLteFlagDefault int64
+
+	_ = cmd.PersistentFlags().Int64(filterRamLteFlagName, filterRamLteFlagDefault, filterRamLteDescription)
 
 	return nil
 }
@@ -488,22 +531,62 @@ func retrieveOperationPlansGetPlansFilterNameFlag(m *plans.GetPlansParams, cmdPr
 	}
 	return nil, retAdded
 }
-func retrieveOperationPlansGetPlansFilterRAMFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+func retrieveOperationPlansGetPlansFilterRAMEqlFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("ram") {
+	if cmd.Flags().Changed("ram_eql") {
 
 		var filterRamFlagName string
 		if cmdPrefix == "" {
-			filterRamFlagName = "ram"
+			filterRamFlagName = "ram_eql"
 		} else {
-			filterRamFlagName = fmt.Sprintf("%v.ram", cmdPrefix)
+			filterRamFlagName = fmt.Sprintf("%v.ram_eql", cmdPrefix)
 		}
 
 		filterRamFlagValue, err := cmd.Flags().GetInt64(filterRamFlagName)
 		if err != nil {
 			return err, false
 		}
-		m.FilterRAM = &filterRamFlagValue
+		m.FilterRAMEql = &filterRamFlagValue
+
+	}
+	return nil, retAdded
+}
+func retrieveOperationPlansGetPlansFilterRAMLteFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	retAdded := false
+	if cmd.Flags().Changed("ram_lte") {
+
+		var filterRamFlagName string
+		if cmdPrefix == "" {
+			filterRamFlagName = "ram_lte"
+		} else {
+			filterRamFlagName = fmt.Sprintf("%v.ram_lte", cmdPrefix)
+		}
+
+		filterRamFlagValue, err := cmd.Flags().GetInt64(filterRamFlagName)
+		if err != nil {
+			return err, false
+		}
+		m.FilterRAMLte = &filterRamFlagValue
+
+	}
+	return nil, retAdded
+}
+func retrieveOperationPlansGetPlansFilterRAMGteFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	retAdded := false
+	if cmd.Flags().Changed("ram_gte") {
+
+		var filterRamFlagName string
+		if cmdPrefix == "" {
+			filterRamFlagName = "ram_gte"
+		} else {
+			filterRamFlagName = fmt.Sprintf("%v.ram_gte", cmdPrefix)
+		}
+
+		filterRamFlagValue, err := cmd.Flags().GetInt64(filterRamFlagName)
+		if err != nil {
+			return err, false
+		}
+		m.FilterRAMGte = &filterRamFlagValue
 
 	}
 	return nil, retAdded

--- a/cli/get_plans_operation.go
+++ b/cli/get_plans_operation.go
@@ -42,7 +42,13 @@ func runOperationPlansGetPlans(cmd *cobra.Command, args []string) error {
 	if err, _ := retrieveOperationPlansGetPlansAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}
-	if err, _ := retrieveOperationPlansGetPlansFilterDiskFlag(params, "", cmd); err != nil {
+	if err, _ := retrieveOperationPlansGetPlansFilterDiskEqlFlag(params, "", cmd); err != nil {
+		return err
+	}
+	if err, _ := retrieveOperationPlansGetPlansFilterDiskLteFlag(params, "", cmd); err != nil {
+		return err
+	}
+	if err, _ := retrieveOperationPlansGetPlansFilterDiskGteFlag(params, "", cmd); err != nil {
 		return err
 	}
 	if err, _ := retrieveOperationPlansGetPlansFilterGpuFlag(params, "", cmd); err != nil {
@@ -87,7 +93,13 @@ func registerOperationPlansGetPlansParamFlags(cmd *cobra.Command) error {
 	if err := registerOperationPlansGetPlansAPIVersionParamFlags("", cmd); err != nil {
 		return err
 	}
-	if err := registerOperationPlansGetPlansFilterDiskParamFlags("", cmd); err != nil {
+	if err := registerOperationPlansGetPlansFilterDiskEqlParamFlags("", cmd); err != nil {
+		return err
+	}
+	if err := registerOperationPlansGetPlansFilterDiskLteParamFlags("", cmd); err != nil {
+		return err
+	}
+	if err := registerOperationPlansGetPlansFilterDiskGteParamFlags("", cmd); err != nil {
 		return err
 	}
 	if err := registerOperationPlansGetPlansFilterGpuParamFlags("", cmd); err != nil {
@@ -131,18 +143,49 @@ func registerOperationPlansGetPlansAPIVersionParamFlags(cmdPrefix string, cmd *c
 
 	return nil
 }
-func registerOperationPlansGetPlansFilterDiskParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+func registerOperationPlansGetPlansFilterDiskEqlParamFlags(cmdPrefix string, cmd *cobra.Command) error {
 
-	filterDiskDescription := `The disk size in Gigabytes to filter by, should be used with the following options:
-                              [eql] to filter for values equal to the provided value.
-                              [gte] to filter for values greater or equal to the provided value.
-                              [lte] to filter by values lower or equal to the provided value.`
+	filterDiskDescription := "Filter plans with disk size in Gigabytes equals the provided value."
 
 	var filterDiskFlagName string
 	if cmdPrefix == "" {
-		filterDiskFlagName = "disk"
+		filterDiskFlagName = "disk_eql"
 	} else {
-		filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
+		filterDiskFlagName = fmt.Sprintf("%v.disk_eql", cmdPrefix)
+	}
+
+	var filterDiskFlagDefault int64
+
+	_ = cmd.PersistentFlags().Int64(filterDiskFlagName, filterDiskFlagDefault, filterDiskDescription)
+
+	return nil
+}
+func registerOperationPlansGetPlansFilterDiskLteParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+
+	filterDiskDescription := "Filter plans with disk size in Gigabytes less than or equal the provided value."
+
+	var filterDiskFlagName string
+	if cmdPrefix == "" {
+		filterDiskFlagName = "disk_lte"
+	} else {
+		filterDiskFlagName = fmt.Sprintf("%v.disk_lte", cmdPrefix)
+	}
+
+	var filterDiskFlagDefault int64
+
+	_ = cmd.PersistentFlags().Int64(filterDiskFlagName, filterDiskFlagDefault, filterDiskDescription)
+
+	return nil
+}
+func registerOperationPlansGetPlansFilterDiskGteParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+
+	filterDiskDescription := "Filter plans with disk size in Gigabytes greater than or equal the provided value."
+
+	var filterDiskFlagName string
+	if cmdPrefix == "" {
+		filterDiskFlagName = "disk_gte"
+	} else {
+		filterDiskFlagName = fmt.Sprintf("%v.disk_gte", cmdPrefix)
 	}
 
 	var filterDiskFlagDefault int64
@@ -305,22 +348,62 @@ func retrieveOperationPlansGetPlansAPIVersionFlag(m *plans.GetPlansParams, cmdPr
 	}
 	return nil, retAdded
 }
-func retrieveOperationPlansGetPlansFilterDiskFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+func retrieveOperationPlansGetPlansFilterDiskEqlFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("disk") {
+	if cmd.Flags().Changed("disk_eql") {
 
 		var filterDiskFlagName string
 		if cmdPrefix == "" {
-			filterDiskFlagName = "disk"
+			filterDiskFlagName = "disk_eql"
 		} else {
-			filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
+			filterDiskFlagName = fmt.Sprintf("%v.disk_eql", cmdPrefix)
 		}
 
 		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
 		if err != nil {
 			return err, false
 		}
-		m.FilterDisk = &filterDiskFlagValue
+		m.FilterDiskEql = &filterDiskFlagValue
+
+	}
+	return nil, retAdded
+}
+func retrieveOperationPlansGetPlansFilterDiskLteFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	retAdded := false
+	if cmd.Flags().Changed("disk_lte") {
+
+		var filterDiskFlagName string
+		if cmdPrefix == "" {
+			filterDiskFlagName = "disk_lte"
+		} else {
+			filterDiskFlagName = fmt.Sprintf("%v.disk_lte", cmdPrefix)
+		}
+
+		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
+		if err != nil {
+			return err, false
+		}
+		m.FilterDiskLte = &filterDiskFlagValue
+
+	}
+	return nil, retAdded
+}
+func retrieveOperationPlansGetPlansFilterDiskGteFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	retAdded := false
+	if cmd.Flags().Changed("disk_gte") {
+
+		var filterDiskFlagName string
+		if cmdPrefix == "" {
+			filterDiskFlagName = "disk_gte"
+		} else {
+			filterDiskFlagName = fmt.Sprintf("%v.disk_gte", cmdPrefix)
+		}
+
+		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
+		if err != nil {
+			return err, false
+		}
+		m.FilterDiskGte = &filterDiskFlagValue
 
 	}
 	return nil, retAdded

--- a/cli/get_plans_operation.go
+++ b/cli/get_plans_operation.go
@@ -140,9 +140,9 @@ func registerOperationPlansGetPlansFilterDiskParamFlags(cmdPrefix string, cmd *c
 
 	var filterDiskFlagName string
 	if cmdPrefix == "" {
-		filterDiskFlagName = "filter[disk]"
+		filterDiskFlagName = "disk"
 	} else {
-		filterDiskFlagName = fmt.Sprintf("%v.filter[disk]", cmdPrefix)
+		filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
 	}
 
 	var filterDiskFlagDefault int64
@@ -157,9 +157,9 @@ func registerOperationPlansGetPlansFilterGpuParamFlags(cmdPrefix string, cmd *co
 
 	var filterGpuFlagName string
 	if cmdPrefix == "" {
-		filterGpuFlagName = "filter[gpu]"
+		filterGpuFlagName = "gpu"
 	} else {
-		filterGpuFlagName = fmt.Sprintf("%v.filter[gpu]", cmdPrefix)
+		filterGpuFlagName = fmt.Sprintf("%v.gpu", cmdPrefix)
 	}
 
 	var filterGpuFlagDefault bool
@@ -174,9 +174,9 @@ func registerOperationPlansGetPlansFilterInStockParamFlags(cmdPrefix string, cmd
 
 	var filterInStockFlagName string
 	if cmdPrefix == "" {
-		filterInStockFlagName = "filter[in_stock]"
+		filterInStockFlagName = "in_stock"
 	} else {
-		filterInStockFlagName = fmt.Sprintf("%v.filter[in_stock]", cmdPrefix)
+		filterInStockFlagName = fmt.Sprintf("%v.in_stock", cmdPrefix)
 	}
 
 	var filterInStockFlagDefault bool
@@ -191,9 +191,9 @@ func registerOperationPlansGetPlansFilterLocationParamFlags(cmdPrefix string, cm
 
 	var filterLocationFlagName string
 	if cmdPrefix == "" {
-		filterLocationFlagName = "filter[location]"
+		filterLocationFlagName = "location"
 	} else {
-		filterLocationFlagName = fmt.Sprintf("%v.filter[location]", cmdPrefix)
+		filterLocationFlagName = fmt.Sprintf("%v.location", cmdPrefix)
 	}
 
 	var filterLocationFlagDefault string
@@ -208,9 +208,9 @@ func registerOperationPlansGetPlansFilterNameParamFlags(cmdPrefix string, cmd *c
 
 	var filterNameFlagName string
 	if cmdPrefix == "" {
-		filterNameFlagName = "filter[name]"
+		filterNameFlagName = "name"
 	} else {
-		filterNameFlagName = fmt.Sprintf("%v.filter[name]", cmdPrefix)
+		filterNameFlagName = fmt.Sprintf("%v.name", cmdPrefix)
 	}
 
 	var filterNameFlagDefault string
@@ -228,9 +228,9 @@ func registerOperationPlansGetPlansFilterRAMParamFlags(cmdPrefix string, cmd *co
 
 	var filterRamFlagName string
 	if cmdPrefix == "" {
-		filterRamFlagName = "filter[ram]"
+		filterRamFlagName = "ram"
 	} else {
-		filterRamFlagName = fmt.Sprintf("%v.filter[ram]", cmdPrefix)
+		filterRamFlagName = fmt.Sprintf("%v.ram", cmdPrefix)
 	}
 
 	var filterRamFlagDefault int64
@@ -245,9 +245,9 @@ func registerOperationPlansGetPlansFilterSlugParamFlags(cmdPrefix string, cmd *c
 
 	var filterSlugFlagName string
 	if cmdPrefix == "" {
-		filterSlugFlagName = "filter[slug]"
+		filterSlugFlagName = "slug"
 	} else {
-		filterSlugFlagName = fmt.Sprintf("%v.filter[slug]", cmdPrefix)
+		filterSlugFlagName = fmt.Sprintf("%v.slug", cmdPrefix)
 	}
 
 	var filterSlugFlagDefault string
@@ -262,9 +262,9 @@ func registerOperationPlansGetPlansFilterStockLevelParamFlags(cmdPrefix string, 
 
 	var filterStockLevelFlagName string
 	if cmdPrefix == "" {
-		filterStockLevelFlagName = "filter[stock_level]"
+		filterStockLevelFlagName = "stock_level"
 	} else {
-		filterStockLevelFlagName = fmt.Sprintf("%v.filter[stock_level]", cmdPrefix)
+		filterStockLevelFlagName = fmt.Sprintf("%v.stock_level", cmdPrefix)
 	}
 
 	var filterStockLevelFlagDefault string
@@ -307,13 +307,13 @@ func retrieveOperationPlansGetPlansAPIVersionFlag(m *plans.GetPlansParams, cmdPr
 }
 func retrieveOperationPlansGetPlansFilterDiskFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[disk]") {
+	if cmd.Flags().Changed("disk") {
 
 		var filterDiskFlagName string
 		if cmdPrefix == "" {
-			filterDiskFlagName = "filter[disk]"
+			filterDiskFlagName = "disk"
 		} else {
-			filterDiskFlagName = fmt.Sprintf("%v.filter[disk]", cmdPrefix)
+			filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
 		}
 
 		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
@@ -327,13 +327,13 @@ func retrieveOperationPlansGetPlansFilterDiskFlag(m *plans.GetPlansParams, cmdPr
 }
 func retrieveOperationPlansGetPlansFilterGpuFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[gpu]") {
+	if cmd.Flags().Changed("gpu") {
 
 		var filterGpuFlagName string
 		if cmdPrefix == "" {
-			filterGpuFlagName = "filter[gpu]"
+			filterGpuFlagName = "gpu"
 		} else {
-			filterGpuFlagName = fmt.Sprintf("%v.filter[gpu]", cmdPrefix)
+			filterGpuFlagName = fmt.Sprintf("%v.gpu", cmdPrefix)
 		}
 
 		filterGpuFlagValue, err := cmd.Flags().GetBool(filterGpuFlagName)
@@ -347,13 +347,13 @@ func retrieveOperationPlansGetPlansFilterGpuFlag(m *plans.GetPlansParams, cmdPre
 }
 func retrieveOperationPlansGetPlansFilterInStockFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[in_stock]") {
+	if cmd.Flags().Changed("in_stock") {
 
 		var filterInStockFlagName string
 		if cmdPrefix == "" {
-			filterInStockFlagName = "filter[in_stock]"
+			filterInStockFlagName = "in_stock"
 		} else {
-			filterInStockFlagName = fmt.Sprintf("%v.filter[in_stock]", cmdPrefix)
+			filterInStockFlagName = fmt.Sprintf("%v.in_stock", cmdPrefix)
 		}
 
 		filterInStockFlagValue, err := cmd.Flags().GetBool(filterInStockFlagName)
@@ -367,13 +367,13 @@ func retrieveOperationPlansGetPlansFilterInStockFlag(m *plans.GetPlansParams, cm
 }
 func retrieveOperationPlansGetPlansFilterLocationFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[location]") {
+	if cmd.Flags().Changed("location") {
 
 		var filterLocationFlagName string
 		if cmdPrefix == "" {
-			filterLocationFlagName = "filter[location]"
+			filterLocationFlagName = "location"
 		} else {
-			filterLocationFlagName = fmt.Sprintf("%v.filter[location]", cmdPrefix)
+			filterLocationFlagName = fmt.Sprintf("%v.location", cmdPrefix)
 		}
 
 		filterLocationFlagValue, err := cmd.Flags().GetString(filterLocationFlagName)
@@ -387,13 +387,13 @@ func retrieveOperationPlansGetPlansFilterLocationFlag(m *plans.GetPlansParams, c
 }
 func retrieveOperationPlansGetPlansFilterNameFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[name]") {
+	if cmd.Flags().Changed("name") {
 
 		var filterNameFlagName string
 		if cmdPrefix == "" {
-			filterNameFlagName = "filter[name]"
+			filterNameFlagName = "name"
 		} else {
-			filterNameFlagName = fmt.Sprintf("%v.filter[name]", cmdPrefix)
+			filterNameFlagName = fmt.Sprintf("%v.name", cmdPrefix)
 		}
 
 		filterNameFlagValue, err := cmd.Flags().GetString(filterNameFlagName)
@@ -407,13 +407,13 @@ func retrieveOperationPlansGetPlansFilterNameFlag(m *plans.GetPlansParams, cmdPr
 }
 func retrieveOperationPlansGetPlansFilterRAMFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[ram]") {
+	if cmd.Flags().Changed("ram") {
 
 		var filterRamFlagName string
 		if cmdPrefix == "" {
-			filterRamFlagName = "filter[ram]"
+			filterRamFlagName = "ram"
 		} else {
-			filterRamFlagName = fmt.Sprintf("%v.filter[ram]", cmdPrefix)
+			filterRamFlagName = fmt.Sprintf("%v.ram", cmdPrefix)
 		}
 
 		filterRamFlagValue, err := cmd.Flags().GetInt64(filterRamFlagName)
@@ -427,13 +427,13 @@ func retrieveOperationPlansGetPlansFilterRAMFlag(m *plans.GetPlansParams, cmdPre
 }
 func retrieveOperationPlansGetPlansFilterSlugFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[slug]") {
+	if cmd.Flags().Changed("slug") {
 
 		var filterSlugFlagName string
 		if cmdPrefix == "" {
-			filterSlugFlagName = "filter[slug]"
+			filterSlugFlagName = "slug"
 		} else {
-			filterSlugFlagName = fmt.Sprintf("%v.filter[slug]", cmdPrefix)
+			filterSlugFlagName = fmt.Sprintf("%v.slug", cmdPrefix)
 		}
 
 		filterSlugFlagValue, err := cmd.Flags().GetString(filterSlugFlagName)
@@ -447,13 +447,13 @@ func retrieveOperationPlansGetPlansFilterSlugFlag(m *plans.GetPlansParams, cmdPr
 }
 func retrieveOperationPlansGetPlansFilterStockLevelFlag(m *plans.GetPlansParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[stock_level]") {
+	if cmd.Flags().Changed("stock_level") {
 
 		var filterStockLevelFlagName string
 		if cmdPrefix == "" {
-			filterStockLevelFlagName = "filter[stock_level]"
+			filterStockLevelFlagName = "stock_level"
 		} else {
-			filterStockLevelFlagName = fmt.Sprintf("%v.filter[stock_level]", cmdPrefix)
+			filterStockLevelFlagName = fmt.Sprintf("%v.stock_level", cmdPrefix)
 		}
 
 		filterStockLevelFlagValue, err := cmd.Flags().GetString(filterStockLevelFlagName)

--- a/cli/get_projects_operation.go
+++ b/cli/get_projects_operation.go
@@ -143,9 +143,9 @@ func registerOperationProjectsGetProjectsFilterBillingTypeParamFlags(cmdPrefix s
 
 	var filterBillingTypeFlagName string
 	if cmdPrefix == "" {
-		filterBillingTypeFlagName = "filter[billing_type]"
+		filterBillingTypeFlagName = "billing_type"
 	} else {
-		filterBillingTypeFlagName = fmt.Sprintf("%v.filter[billing_type]", cmdPrefix)
+		filterBillingTypeFlagName = fmt.Sprintf("%v.billing_type", cmdPrefix)
 	}
 
 	var filterBillingTypeFlagDefault string
@@ -160,9 +160,9 @@ func registerOperationProjectsGetProjectsFilterDescriptionParamFlags(cmdPrefix s
 
 	var filterDescriptionFlagName string
 	if cmdPrefix == "" {
-		filterDescriptionFlagName = "filter[description]"
+		filterDescriptionFlagName = "description"
 	} else {
-		filterDescriptionFlagName = fmt.Sprintf("%v.filter[description]", cmdPrefix)
+		filterDescriptionFlagName = fmt.Sprintf("%v.description", cmdPrefix)
 	}
 
 	var filterDescriptionFlagDefault string
@@ -177,9 +177,9 @@ func registerOperationProjectsGetProjectsFilterEnvironmentParamFlags(cmdPrefix s
 
 	var filterEnvironmentFlagName string
 	if cmdPrefix == "" {
-		filterEnvironmentFlagName = "filter[environment]"
+		filterEnvironmentFlagName = "environment"
 	} else {
-		filterEnvironmentFlagName = fmt.Sprintf("%v.filter[environment]", cmdPrefix)
+		filterEnvironmentFlagName = fmt.Sprintf("%v.environment", cmdPrefix)
 	}
 
 	var filterEnvironmentFlagDefault string
@@ -193,10 +193,11 @@ func registerOperationProjectsGetProjectsFilterNameParamFlags(cmdPrefix string, 
 	filterNameDescription := `The project name to filter by`
 
 	var filterNameFlagName string
+
 	if cmdPrefix == "" {
-		filterNameFlagName = "filter[name]"
+		filterNameFlagName = "name"
 	} else {
-		filterNameFlagName = fmt.Sprintf("%v.filter[name]", cmdPrefix)
+		filterNameFlagName = fmt.Sprintf("%v.name", cmdPrefix)
 	}
 
 	var filterNameFlagDefault string
@@ -205,15 +206,16 @@ func registerOperationProjectsGetProjectsFilterNameParamFlags(cmdPrefix string, 
 
 	return nil
 }
+
 func registerOperationProjectsGetProjectsFilterSlugParamFlags(cmdPrefix string, cmd *cobra.Command) error {
 
 	filterSlugDescription := `The project slug to filter by`
 
 	var filterSlugFlagName string
 	if cmdPrefix == "" {
-		filterSlugFlagName = "filter[slug]"
+		filterSlugFlagName = "slug"
 	} else {
-		filterSlugFlagName = fmt.Sprintf("%v.filter[slug]", cmdPrefix)
+		filterSlugFlagName = fmt.Sprintf("%v.slug", cmdPrefix)
 	}
 
 	var filterSlugFlagDefault string
@@ -265,13 +267,13 @@ func retrieveOperationProjectsGetProjectsExtraFieldsProjectsFlag(m *projects.Get
 }
 func retrieveOperationProjectsGetProjectsFilterBillingTypeFlag(m *projects.GetProjectsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[billing_type]") {
+	if cmd.Flags().Changed("billing_type") {
 
 		var filterBillingTypeFlagName string
 		if cmdPrefix == "" {
-			filterBillingTypeFlagName = "filter[billing_type]"
+			filterBillingTypeFlagName = "billing_type"
 		} else {
-			filterBillingTypeFlagName = fmt.Sprintf("%v.filter[billing_type]", cmdPrefix)
+			filterBillingTypeFlagName = fmt.Sprintf("%v.billing_type", cmdPrefix)
 		}
 
 		filterBillingTypeFlagValue, err := cmd.Flags().GetString(filterBillingTypeFlagName)
@@ -285,13 +287,13 @@ func retrieveOperationProjectsGetProjectsFilterBillingTypeFlag(m *projects.GetPr
 }
 func retrieveOperationProjectsGetProjectsFilterDescriptionFlag(m *projects.GetProjectsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[description]") {
+	if cmd.Flags().Changed("description") {
 
 		var filterDescriptionFlagName string
 		if cmdPrefix == "" {
-			filterDescriptionFlagName = "filter[description]"
+			filterDescriptionFlagName = "description"
 		} else {
-			filterDescriptionFlagName = fmt.Sprintf("%v.filter[description]", cmdPrefix)
+			filterDescriptionFlagName = fmt.Sprintf("%v.description", cmdPrefix)
 		}
 
 		filterDescriptionFlagValue, err := cmd.Flags().GetString(filterDescriptionFlagName)
@@ -305,13 +307,13 @@ func retrieveOperationProjectsGetProjectsFilterDescriptionFlag(m *projects.GetPr
 }
 func retrieveOperationProjectsGetProjectsFilterEnvironmentFlag(m *projects.GetProjectsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[environment]") {
+	if cmd.Flags().Changed("environment") {
 
 		var filterEnvironmentFlagName string
 		if cmdPrefix == "" {
-			filterEnvironmentFlagName = "filter[environment]"
+			filterEnvironmentFlagName = "environment"
 		} else {
-			filterEnvironmentFlagName = fmt.Sprintf("%v.filter[environment]", cmdPrefix)
+			filterEnvironmentFlagName = fmt.Sprintf("%v.environment", cmdPrefix)
 		}
 
 		filterEnvironmentFlagValue, err := cmd.Flags().GetString(filterEnvironmentFlagName)
@@ -325,13 +327,13 @@ func retrieveOperationProjectsGetProjectsFilterEnvironmentFlag(m *projects.GetPr
 }
 func retrieveOperationProjectsGetProjectsFilterNameFlag(m *projects.GetProjectsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[name]") {
+	if cmd.Flags().Changed("name") {
 
 		var filterNameFlagName string
 		if cmdPrefix == "" {
-			filterNameFlagName = "filter[name]"
+			filterNameFlagName = "name"
 		} else {
-			filterNameFlagName = fmt.Sprintf("%v.filter[name]", cmdPrefix)
+			filterNameFlagName = fmt.Sprintf("%v.name", cmdPrefix)
 		}
 
 		filterNameFlagValue, err := cmd.Flags().GetString(filterNameFlagName)
@@ -345,13 +347,13 @@ func retrieveOperationProjectsGetProjectsFilterNameFlag(m *projects.GetProjectsP
 }
 func retrieveOperationProjectsGetProjectsFilterSlugFlag(m *projects.GetProjectsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[slug]") {
+	if cmd.Flags().Changed("slug") {
 
 		var filterSlugFlagName string
 		if cmdPrefix == "" {
-			filterSlugFlagName = "filter[slug]"
+			filterSlugFlagName = "slug"
 		} else {
-			filterSlugFlagName = fmt.Sprintf("%v.filter[slug]", cmdPrefix)
+			filterSlugFlagName = fmt.Sprintf("%v.slug", cmdPrefix)
 		}
 
 		filterSlugFlagValue, err := cmd.Flags().GetString(filterSlugFlagName)

--- a/cli/get_servers_operation.go
+++ b/cli/get_servers_operation.go
@@ -197,9 +197,9 @@ func registerOperationServersGetServersFilterCreatedAtGteParamFlags(cmdPrefix st
 
 	var filterCreatedAtGteFlagName string
 	if cmdPrefix == "" {
-		filterCreatedAtGteFlagName = "filter[created_at_gte]"
+		filterCreatedAtGteFlagName = "created_at_gte"
 	} else {
-		filterCreatedAtGteFlagName = fmt.Sprintf("%v.filter[created_at_gte]", cmdPrefix)
+		filterCreatedAtGteFlagName = fmt.Sprintf("%v.created_at_gte", cmdPrefix)
 	}
 
 	var filterCreatedAtGteFlagDefault string
@@ -214,9 +214,9 @@ func registerOperationServersGetServersFilterCreatedAtLteParamFlags(cmdPrefix st
 
 	var filterCreatedAtLteFlagName string
 	if cmdPrefix == "" {
-		filterCreatedAtLteFlagName = "filter[created_at_lte]"
+		filterCreatedAtLteFlagName = "created_at_lte"
 	} else {
-		filterCreatedAtLteFlagName = fmt.Sprintf("%v.filter[created_at_lte]", cmdPrefix)
+		filterCreatedAtLteFlagName = fmt.Sprintf("%v.created_at_lte", cmdPrefix)
 	}
 
 	var filterCreatedAtLteFlagDefault string
@@ -234,9 +234,9 @@ func registerOperationServersGetServersFilterDiskParamFlags(cmdPrefix string, cm
 
 	var filterDiskFlagName string
 	if cmdPrefix == "" {
-		filterDiskFlagName = "filter[disk]"
+		filterDiskFlagName = "disk"
 	} else {
-		filterDiskFlagName = fmt.Sprintf("%v.filter[disk]", cmdPrefix)
+		filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
 	}
 
 	var filterDiskFlagDefault int64
@@ -251,9 +251,9 @@ func registerOperationServersGetServersFilterGpuParamFlags(cmdPrefix string, cmd
 
 	var filterGpuFlagName string
 	if cmdPrefix == "" {
-		filterGpuFlagName = "filter[gpu]"
+		filterGpuFlagName = "gpu"
 	} else {
-		filterGpuFlagName = fmt.Sprintf("%v.filter[gpu]", cmdPrefix)
+		filterGpuFlagName = fmt.Sprintf("%v.gpu", cmdPrefix)
 	}
 
 	var filterGpuFlagDefault bool
@@ -268,9 +268,9 @@ func registerOperationServersGetServersFilterHostnameParamFlags(cmdPrefix string
 
 	var filterHostnameFlagName string
 	if cmdPrefix == "" {
-		filterHostnameFlagName = "filter[hostname]"
+		filterHostnameFlagName = "hostname"
 	} else {
-		filterHostnameFlagName = fmt.Sprintf("%v.filter[hostname]", cmdPrefix)
+		filterHostnameFlagName = fmt.Sprintf("%v.hostname", cmdPrefix)
 	}
 
 	var filterHostnameFlagDefault string
@@ -285,9 +285,9 @@ func registerOperationServersGetServersFilterLabelParamFlags(cmdPrefix string, c
 
 	var filterLabelFlagName string
 	if cmdPrefix == "" {
-		filterLabelFlagName = "filter[label]"
+		filterLabelFlagName = "label"
 	} else {
-		filterLabelFlagName = fmt.Sprintf("%v.filter[label]", cmdPrefix)
+		filterLabelFlagName = fmt.Sprintf("%v.label", cmdPrefix)
 	}
 
 	var filterLabelFlagDefault string
@@ -302,9 +302,9 @@ func registerOperationServersGetServersFilterOperatingSystemParamFlags(cmdPrefix
 
 	var filterOperatingSystemFlagName string
 	if cmdPrefix == "" {
-		filterOperatingSystemFlagName = "filter[operating_system]"
+		filterOperatingSystemFlagName = "operating_system"
 	} else {
-		filterOperatingSystemFlagName = fmt.Sprintf("%v.filter[operating_system]", cmdPrefix)
+		filterOperatingSystemFlagName = fmt.Sprintf("%v.operating_system", cmdPrefix)
 	}
 
 	var filterOperatingSystemFlagDefault string
@@ -319,9 +319,9 @@ func registerOperationServersGetServersFilterPlanParamFlags(cmdPrefix string, cm
 
 	var filterPlanFlagName string
 	if cmdPrefix == "" {
-		filterPlanFlagName = "filter[plan]"
+		filterPlanFlagName = "plan"
 	} else {
-		filterPlanFlagName = fmt.Sprintf("%v.filter[plan]", cmdPrefix)
+		filterPlanFlagName = fmt.Sprintf("%v.plan", cmdPrefix)
 	}
 
 	var filterPlanFlagDefault string
@@ -336,9 +336,9 @@ func registerOperationServersGetServersFilterProjectParamFlags(cmdPrefix string,
 
 	var filterProjectFlagName string
 	if cmdPrefix == "" {
-		filterProjectFlagName = "filter[project]"
+		filterProjectFlagName = "project"
 	} else {
-		filterProjectFlagName = fmt.Sprintf("%v.filter[project]", cmdPrefix)
+		filterProjectFlagName = fmt.Sprintf("%v.project", cmdPrefix)
 	}
 
 	var filterProjectFlagDefault string
@@ -353,9 +353,9 @@ func registerOperationServersGetServersFilterRAMEqlParamFlags(cmdPrefix string, 
 
 	var filterRamEqlFlagName string
 	if cmdPrefix == "" {
-		filterRamEqlFlagName = "filter[ram][eql]"
+		filterRamEqlFlagName = "ram[eql]"
 	} else {
-		filterRamEqlFlagName = fmt.Sprintf("%v.filter[ram][eql]", cmdPrefix)
+		filterRamEqlFlagName = fmt.Sprintf("%v.ram[eql]", cmdPrefix)
 	}
 
 	var filterRamEqlFlagDefault int64
@@ -370,9 +370,9 @@ func registerOperationServersGetServersFilterRAMGteParamFlags(cmdPrefix string, 
 
 	var filterRamGteFlagName string
 	if cmdPrefix == "" {
-		filterRamGteFlagName = "filter[ram][gte]"
+		filterRamGteFlagName = "ram[gte]"
 	} else {
-		filterRamGteFlagName = fmt.Sprintf("%v.filter[ram][gte]", cmdPrefix)
+		filterRamGteFlagName = fmt.Sprintf("%v.ram[gte]", cmdPrefix)
 	}
 
 	var filterRamGteFlagDefault int64
@@ -387,9 +387,9 @@ func registerOperationServersGetServersFilterRAMLteParamFlags(cmdPrefix string, 
 
 	var filterRamLteFlagName string
 	if cmdPrefix == "" {
-		filterRamLteFlagName = "filter[ram][lte]"
+		filterRamLteFlagName = "ram[lte]"
 	} else {
-		filterRamLteFlagName = fmt.Sprintf("%v.filter[ram][lte]", cmdPrefix)
+		filterRamLteFlagName = fmt.Sprintf("%v.ram[lte]", cmdPrefix)
 	}
 
 	var filterRamLteFlagDefault int64
@@ -404,9 +404,9 @@ func registerOperationServersGetServersFilterRegionParamFlags(cmdPrefix string, 
 
 	var filterRegionFlagName string
 	if cmdPrefix == "" {
-		filterRegionFlagName = "filter[region]"
+		filterRegionFlagName = "region"
 	} else {
-		filterRegionFlagName = fmt.Sprintf("%v.filter[region]", cmdPrefix)
+		filterRegionFlagName = fmt.Sprintf("%v.region", cmdPrefix)
 	}
 
 	var filterRegionFlagDefault string
@@ -421,9 +421,9 @@ func registerOperationServersGetServersFilterStatusParamFlags(cmdPrefix string, 
 
 	var filterStatusFlagName string
 	if cmdPrefix == "" {
-		filterStatusFlagName = "filter[status]"
+		filterStatusFlagName = "status"
 	} else {
-		filterStatusFlagName = fmt.Sprintf("%v.filter[status]", cmdPrefix)
+		filterStatusFlagName = fmt.Sprintf("%v.status", cmdPrefix)
 	}
 
 	var filterStatusFlagDefault string
@@ -475,13 +475,13 @@ func retrieveOperationServersGetServersExtraFieldsServersFlag(m *servers.GetServ
 }
 func retrieveOperationServersGetServersFilterCreatedAtGteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[created_at_gte]") {
+	if cmd.Flags().Changed("created_at_gte") {
 
 		var filterCreatedAtGteFlagName string
 		if cmdPrefix == "" {
-			filterCreatedAtGteFlagName = "filter[created_at_gte]"
+			filterCreatedAtGteFlagName = "created_at_gte"
 		} else {
-			filterCreatedAtGteFlagName = fmt.Sprintf("%v.filter[created_at_gte]", cmdPrefix)
+			filterCreatedAtGteFlagName = fmt.Sprintf("%v.created_at_gte", cmdPrefix)
 		}
 
 		filterCreatedAtGteFlagValue, err := cmd.Flags().GetString(filterCreatedAtGteFlagName)
@@ -495,13 +495,13 @@ func retrieveOperationServersGetServersFilterCreatedAtGteFlag(m *servers.GetServ
 }
 func retrieveOperationServersGetServersFilterCreatedAtLteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[created_at_lte]") {
+	if cmd.Flags().Changed("created_at_lte") {
 
 		var filterCreatedAtLteFlagName string
 		if cmdPrefix == "" {
-			filterCreatedAtLteFlagName = "filter[created_at_lte]"
+			filterCreatedAtLteFlagName = "created_at_lte"
 		} else {
-			filterCreatedAtLteFlagName = fmt.Sprintf("%v.filter[created_at_lte]", cmdPrefix)
+			filterCreatedAtLteFlagName = fmt.Sprintf("%v.created_at_lte", cmdPrefix)
 		}
 
 		filterCreatedAtLteFlagValue, err := cmd.Flags().GetString(filterCreatedAtLteFlagName)
@@ -515,13 +515,13 @@ func retrieveOperationServersGetServersFilterCreatedAtLteFlag(m *servers.GetServ
 }
 func retrieveOperationServersGetServersFilterDiskFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[disk]") {
+	if cmd.Flags().Changed("disk") {
 
 		var filterDiskFlagName string
 		if cmdPrefix == "" {
-			filterDiskFlagName = "filter[disk]"
+			filterDiskFlagName = "disk"
 		} else {
-			filterDiskFlagName = fmt.Sprintf("%v.filter[disk]", cmdPrefix)
+			filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
 		}
 
 		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
@@ -535,13 +535,13 @@ func retrieveOperationServersGetServersFilterDiskFlag(m *servers.GetServersParam
 }
 func retrieveOperationServersGetServersFilterGpuFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[gpu]") {
+	if cmd.Flags().Changed("gpu") {
 
 		var filterGpuFlagName string
 		if cmdPrefix == "" {
-			filterGpuFlagName = "filter[gpu]"
+			filterGpuFlagName = "gpu"
 		} else {
-			filterGpuFlagName = fmt.Sprintf("%v.filter[gpu]", cmdPrefix)
+			filterGpuFlagName = fmt.Sprintf("%v.gpu", cmdPrefix)
 		}
 
 		filterGpuFlagValue, err := cmd.Flags().GetBool(filterGpuFlagName)
@@ -555,13 +555,13 @@ func retrieveOperationServersGetServersFilterGpuFlag(m *servers.GetServersParams
 }
 func retrieveOperationServersGetServersFilterHostnameFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[hostname]") {
+	if cmd.Flags().Changed("hostname") {
 
 		var filterHostnameFlagName string
 		if cmdPrefix == "" {
-			filterHostnameFlagName = "filter[hostname]"
+			filterHostnameFlagName = "hostname"
 		} else {
-			filterHostnameFlagName = fmt.Sprintf("%v.filter[hostname]", cmdPrefix)
+			filterHostnameFlagName = fmt.Sprintf("%v.hostname", cmdPrefix)
 		}
 
 		filterHostnameFlagValue, err := cmd.Flags().GetString(filterHostnameFlagName)
@@ -575,13 +575,13 @@ func retrieveOperationServersGetServersFilterHostnameFlag(m *servers.GetServersP
 }
 func retrieveOperationServersGetServersFilterLabelFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[label]") {
+	if cmd.Flags().Changed("label") {
 
 		var filterLabelFlagName string
 		if cmdPrefix == "" {
-			filterLabelFlagName = "filter[label]"
+			filterLabelFlagName = "label"
 		} else {
-			filterLabelFlagName = fmt.Sprintf("%v.filter[label]", cmdPrefix)
+			filterLabelFlagName = fmt.Sprintf("%v.label", cmdPrefix)
 		}
 
 		filterLabelFlagValue, err := cmd.Flags().GetString(filterLabelFlagName)
@@ -595,13 +595,13 @@ func retrieveOperationServersGetServersFilterLabelFlag(m *servers.GetServersPara
 }
 func retrieveOperationServersGetServersFilterOperatingSystemFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[operating_system]") {
+	if cmd.Flags().Changed("operating_system") {
 
 		var filterOperatingSystemFlagName string
 		if cmdPrefix == "" {
-			filterOperatingSystemFlagName = "filter[operating_system]"
+			filterOperatingSystemFlagName = "operating_system"
 		} else {
-			filterOperatingSystemFlagName = fmt.Sprintf("%v.filter[operating_system]", cmdPrefix)
+			filterOperatingSystemFlagName = fmt.Sprintf("%v.operating_system", cmdPrefix)
 		}
 
 		filterOperatingSystemFlagValue, err := cmd.Flags().GetString(filterOperatingSystemFlagName)
@@ -615,13 +615,13 @@ func retrieveOperationServersGetServersFilterOperatingSystemFlag(m *servers.GetS
 }
 func retrieveOperationServersGetServersFilterPlanFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[plan]") {
+	if cmd.Flags().Changed("plan") {
 
 		var filterPlanFlagName string
 		if cmdPrefix == "" {
-			filterPlanFlagName = "filter[plan]"
+			filterPlanFlagName = "plan"
 		} else {
-			filterPlanFlagName = fmt.Sprintf("%v.filter[plan]", cmdPrefix)
+			filterPlanFlagName = fmt.Sprintf("%v.plan", cmdPrefix)
 		}
 
 		filterPlanFlagValue, err := cmd.Flags().GetString(filterPlanFlagName)
@@ -635,13 +635,13 @@ func retrieveOperationServersGetServersFilterPlanFlag(m *servers.GetServersParam
 }
 func retrieveOperationServersGetServersFilterProjectFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[project]") {
+	if cmd.Flags().Changed("project") {
 
 		var filterProjectFlagName string
 		if cmdPrefix == "" {
-			filterProjectFlagName = "filter[project]"
+			filterProjectFlagName = "project"
 		} else {
-			filterProjectFlagName = fmt.Sprintf("%v.filter[project]", cmdPrefix)
+			filterProjectFlagName = fmt.Sprintf("%v.project", cmdPrefix)
 		}
 
 		filterProjectFlagValue, err := cmd.Flags().GetString(filterProjectFlagName)
@@ -655,13 +655,13 @@ func retrieveOperationServersGetServersFilterProjectFlag(m *servers.GetServersPa
 }
 func retrieveOperationServersGetServersFilterRAMEqlFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[ram][eql]") {
+	if cmd.Flags().Changed("ram[eql]") {
 
 		var filterRamEqlFlagName string
 		if cmdPrefix == "" {
-			filterRamEqlFlagName = "filter[ram][eql]"
+			filterRamEqlFlagName = "ram[eql]"
 		} else {
-			filterRamEqlFlagName = fmt.Sprintf("%v.filter[ram][eql]", cmdPrefix)
+			filterRamEqlFlagName = fmt.Sprintf("%v.ram[eql]", cmdPrefix)
 		}
 
 		filterRamEqlFlagValue, err := cmd.Flags().GetInt64(filterRamEqlFlagName)
@@ -675,13 +675,13 @@ func retrieveOperationServersGetServersFilterRAMEqlFlag(m *servers.GetServersPar
 }
 func retrieveOperationServersGetServersFilterRAMGteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[ram][gte]") {
+	if cmd.Flags().Changed("ram[gte]") {
 
 		var filterRamGteFlagName string
 		if cmdPrefix == "" {
-			filterRamGteFlagName = "filter[ram][gte]"
+			filterRamGteFlagName = "ram[gte]"
 		} else {
-			filterRamGteFlagName = fmt.Sprintf("%v.filter[ram][gte]", cmdPrefix)
+			filterRamGteFlagName = fmt.Sprintf("%v.ram[gte]", cmdPrefix)
 		}
 
 		filterRamGteFlagValue, err := cmd.Flags().GetInt64(filterRamGteFlagName)
@@ -695,13 +695,13 @@ func retrieveOperationServersGetServersFilterRAMGteFlag(m *servers.GetServersPar
 }
 func retrieveOperationServersGetServersFilterRAMLteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[ram][lte]") {
+	if cmd.Flags().Changed("ram[lte]") {
 
 		var filterRamLteFlagName string
 		if cmdPrefix == "" {
-			filterRamLteFlagName = "filter[ram][lte]"
+			filterRamLteFlagName = "ram[lte]"
 		} else {
-			filterRamLteFlagName = fmt.Sprintf("%v.filter[ram][lte]", cmdPrefix)
+			filterRamLteFlagName = fmt.Sprintf("%v.ram[lte]", cmdPrefix)
 		}
 
 		filterRamLteFlagValue, err := cmd.Flags().GetInt64(filterRamLteFlagName)
@@ -715,13 +715,13 @@ func retrieveOperationServersGetServersFilterRAMLteFlag(m *servers.GetServersPar
 }
 func retrieveOperationServersGetServersFilterRegionFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[region]") {
+	if cmd.Flags().Changed("region") {
 
 		var filterRegionFlagName string
 		if cmdPrefix == "" {
-			filterRegionFlagName = "filter[region]"
+			filterRegionFlagName = "region"
 		} else {
-			filterRegionFlagName = fmt.Sprintf("%v.filter[region]", cmdPrefix)
+			filterRegionFlagName = fmt.Sprintf("%v.region", cmdPrefix)
 		}
 
 		filterRegionFlagValue, err := cmd.Flags().GetString(filterRegionFlagName)
@@ -735,13 +735,13 @@ func retrieveOperationServersGetServersFilterRegionFlag(m *servers.GetServersPar
 }
 func retrieveOperationServersGetServersFilterStatusFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[status]") {
+	if cmd.Flags().Changed("status") {
 
 		var filterStatusFlagName string
 		if cmdPrefix == "" {
-			filterStatusFlagName = "filter[status]"
+			filterStatusFlagName = "status"
 		} else {
-			filterStatusFlagName = fmt.Sprintf("%v.filter[status]", cmdPrefix)
+			filterStatusFlagName = fmt.Sprintf("%v.status", cmdPrefix)
 		}
 
 		filterStatusFlagValue, err := cmd.Flags().GetString(filterStatusFlagName)

--- a/cli/get_servers_operation.go
+++ b/cli/get_servers_operation.go
@@ -124,7 +124,13 @@ func registerOperationServersGetServersParamFlags(cmd *cobra.Command) error {
 	if err := registerOperationServersGetServersFilterCreatedAtLteParamFlags("", cmd); err != nil {
 		return err
 	}
-	if err := registerOperationServersGetServersFilterDiskParamFlags("", cmd); err != nil {
+	if err := registerOperationServersGetServersFilterDiskEqlParamFlags("", cmd); err != nil {
+		return err
+	}
+	if err := registerOperationServersGetServersFilterDiskLteParamFlags("", cmd); err != nil {
+		return err
+	}
+	if err := registerOperationServersGetServersFilterDiskGteParamFlags("", cmd); err != nil {
 		return err
 	}
 	if err := registerOperationServersGetServersFilterGpuParamFlags("", cmd); err != nil {
@@ -231,18 +237,49 @@ func registerOperationServersGetServersFilterCreatedAtLteParamFlags(cmdPrefix st
 
 	return nil
 }
-func registerOperationServersGetServersFilterDiskParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+func registerOperationServersGetServersFilterDiskEqlParamFlags(cmdPrefix string, cmd *cobra.Command) error {
 
-	filterDiskDescription := `The disk size in Gigabytes to filter by, should be used with the following options:
-                              [eql] to filter for values equal to the provided value.
-                              [gte] to filter for values greater or equal to the provided value.
-                              [lte] to filter by values lower or equal to the provided value.`
+	filterDiskDescription := "Filter servers with disk size in Gigabytes equal the provided value."
 
 	var filterDiskFlagName string
 	if cmdPrefix == "" {
-		filterDiskFlagName = "disk"
+		filterDiskFlagName = "disk_eql"
 	} else {
-		filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
+		filterDiskFlagName = fmt.Sprintf("%v.disk_eql", cmdPrefix)
+	}
+
+	var filterDiskFlagDefault int64
+
+	_ = cmd.PersistentFlags().Int64(filterDiskFlagName, filterDiskFlagDefault, filterDiskDescription)
+
+	return nil
+}
+func registerOperationServersGetServersFilterDiskLteParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+
+	filterDiskDescription := "Filter servers with disk size in Gigabytes less than or equal the provided value."
+
+	var filterDiskFlagName string
+	if cmdPrefix == "" {
+		filterDiskFlagName = "disk_lte"
+	} else {
+		filterDiskFlagName = fmt.Sprintf("%v.disk_lte", cmdPrefix)
+	}
+
+	var filterDiskFlagDefault int64
+
+	_ = cmd.PersistentFlags().Int64(filterDiskFlagName, filterDiskFlagDefault, filterDiskDescription)
+
+	return nil
+}
+func registerOperationServersGetServersFilterDiskGteParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+
+	filterDiskDescription := "Filter servers with disk size in Gigabytes greater than or equal the provided value."
+
+	var filterDiskFlagName string
+	if cmdPrefix == "" {
+		filterDiskFlagName = "disk_gte"
+	} else {
+		filterDiskFlagName = fmt.Sprintf("%v.disk_gte", cmdPrefix)
 	}
 
 	var filterDiskFlagDefault int64
@@ -359,9 +396,9 @@ func registerOperationServersGetServersFilterRAMEqlParamFlags(cmdPrefix string, 
 
 	var filterRamEqlFlagName string
 	if cmdPrefix == "" {
-		filterRamEqlFlagName = "ram[eql]"
+		filterRamEqlFlagName = "ram_eql"
 	} else {
-		filterRamEqlFlagName = fmt.Sprintf("%v.ram[eql]", cmdPrefix)
+		filterRamEqlFlagName = fmt.Sprintf("%v.ram_eql", cmdPrefix)
 	}
 
 	var filterRamEqlFlagDefault int64
@@ -376,9 +413,9 @@ func registerOperationServersGetServersFilterRAMGteParamFlags(cmdPrefix string, 
 
 	var filterRamGteFlagName string
 	if cmdPrefix == "" {
-		filterRamGteFlagName = "ram[gte]"
+		filterRamGteFlagName = "ram_gte"
 	} else {
-		filterRamGteFlagName = fmt.Sprintf("%v.ram[gte]", cmdPrefix)
+		filterRamGteFlagName = fmt.Sprintf("%v.ram_gte", cmdPrefix)
 	}
 
 	var filterRamGteFlagDefault int64
@@ -393,9 +430,9 @@ func registerOperationServersGetServersFilterRAMLteParamFlags(cmdPrefix string, 
 
 	var filterRamLteFlagName string
 	if cmdPrefix == "" {
-		filterRamLteFlagName = "ram[lte]"
+		filterRamLteFlagName = "ram_lte"
 	} else {
-		filterRamLteFlagName = fmt.Sprintf("%v.ram[lte]", cmdPrefix)
+		filterRamLteFlagName = fmt.Sprintf("%v.ram_lte", cmdPrefix)
 	}
 
 	var filterRamLteFlagDefault int64
@@ -701,13 +738,13 @@ func retrieveOperationServersGetServersFilterProjectFlag(m *servers.GetServersPa
 }
 func retrieveOperationServersGetServersFilterRAMEqlFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("ram[eql]") {
+	if cmd.Flags().Changed("ram_eql") {
 
 		var filterRamEqlFlagName string
 		if cmdPrefix == "" {
-			filterRamEqlFlagName = "ram[eql]"
+			filterRamEqlFlagName = "ram_eql"
 		} else {
-			filterRamEqlFlagName = fmt.Sprintf("%v.ram[eql]", cmdPrefix)
+			filterRamEqlFlagName = fmt.Sprintf("%v.ram_eql", cmdPrefix)
 		}
 
 		filterRamEqlFlagValue, err := cmd.Flags().GetInt64(filterRamEqlFlagName)
@@ -721,13 +758,13 @@ func retrieveOperationServersGetServersFilterRAMEqlFlag(m *servers.GetServersPar
 }
 func retrieveOperationServersGetServersFilterRAMGteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("ram[gte]") {
+	if cmd.Flags().Changed("ram_gte") {
 
 		var filterRamGteFlagName string
 		if cmdPrefix == "" {
-			filterRamGteFlagName = "ram[gte]"
+			filterRamGteFlagName = "ram_gte"
 		} else {
-			filterRamGteFlagName = fmt.Sprintf("%v.ram[gte]", cmdPrefix)
+			filterRamGteFlagName = fmt.Sprintf("%v.ram_gte", cmdPrefix)
 		}
 
 		filterRamGteFlagValue, err := cmd.Flags().GetInt64(filterRamGteFlagName)
@@ -741,13 +778,13 @@ func retrieveOperationServersGetServersFilterRAMGteFlag(m *servers.GetServersPar
 }
 func retrieveOperationServersGetServersFilterRAMLteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("ram[lte]") {
+	if cmd.Flags().Changed("ram_lte") {
 
 		var filterRamLteFlagName string
 		if cmdPrefix == "" {
-			filterRamLteFlagName = "ram[lte]"
+			filterRamLteFlagName = "ram_lte"
 		} else {
-			filterRamLteFlagName = fmt.Sprintf("%v.ram[lte]", cmdPrefix)
+			filterRamLteFlagName = fmt.Sprintf("%v.ram_lte", cmdPrefix)
 		}
 
 		filterRamLteFlagValue, err := cmd.Flags().GetInt64(filterRamLteFlagName)

--- a/cli/get_servers_operation.go
+++ b/cli/get_servers_operation.go
@@ -51,7 +51,13 @@ func runOperationServersGetServers(cmd *cobra.Command, args []string) error {
 	if err, _ := retrieveOperationServersGetServersFilterCreatedAtLteFlag(params, "", cmd); err != nil {
 		return err
 	}
-	if err, _ := retrieveOperationServersGetServersFilterDiskFlag(params, "", cmd); err != nil {
+	if err, _ := retrieveOperationServersGetServersFilterDiskEqlFlag(params, "", cmd); err != nil {
+		return err
+	}
+	if err, _ := retrieveOperationServersGetServersFilterDiskLteFlag(params, "", cmd); err != nil {
+		return err
+	}
+	if err, _ := retrieveOperationServersGetServersFilterDiskGteFlag(params, "", cmd); err != nil {
 		return err
 	}
 	if err, _ := retrieveOperationServersGetServersFilterGpuFlag(params, "", cmd); err != nil {
@@ -513,22 +519,62 @@ func retrieveOperationServersGetServersFilterCreatedAtLteFlag(m *servers.GetServ
 	}
 	return nil, retAdded
 }
-func retrieveOperationServersGetServersFilterDiskFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+func retrieveOperationServersGetServersFilterDiskEqlFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("disk") {
+	if cmd.Flags().Changed("disk_eql") {
 
 		var filterDiskFlagName string
 		if cmdPrefix == "" {
-			filterDiskFlagName = "disk"
+			filterDiskFlagName = "disk_eql"
 		} else {
-			filterDiskFlagName = fmt.Sprintf("%v.disk", cmdPrefix)
+			filterDiskFlagName = fmt.Sprintf("%v.disk_eql", cmdPrefix)
 		}
 
 		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
 		if err != nil {
 			return err, false
 		}
-		m.FilterDisk = &filterDiskFlagValue
+		m.FilterDiskEql = &filterDiskFlagValue
+
+	}
+	return nil, retAdded
+}
+func retrieveOperationServersGetServersFilterDiskLteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	retAdded := false
+	if cmd.Flags().Changed("disk_lte") {
+
+		var filterDiskFlagName string
+		if cmdPrefix == "" {
+			filterDiskFlagName = "disk_lte"
+		} else {
+			filterDiskFlagName = fmt.Sprintf("%v.disk_lte", cmdPrefix)
+		}
+
+		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
+		if err != nil {
+			return err, false
+		}
+		m.FilterDiskLte = &filterDiskFlagValue
+
+	}
+	return nil, retAdded
+}
+func retrieveOperationServersGetServersFilterDiskGteFlag(m *servers.GetServersParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	retAdded := false
+	if cmd.Flags().Changed("disk_gte") {
+
+		var filterDiskFlagName string
+		if cmdPrefix == "" {
+			filterDiskFlagName = "disk_gte"
+		} else {
+			filterDiskFlagName = fmt.Sprintf("%v.disk_gte", cmdPrefix)
+		}
+
+		filterDiskFlagValue, err := cmd.Flags().GetInt64(filterDiskFlagName)
+		if err != nil {
+			return err, false
+		}
+		m.FilterDiskGte = &filterDiskFlagValue
 
 	}
 	return nil, retAdded

--- a/cli/get_virtual_networks_assignments_operation.go
+++ b/cli/get_virtual_networks_assignments_operation.go
@@ -108,9 +108,9 @@ func registerOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilt
 
 	var filterServerFlagName string
 	if cmdPrefix == "" {
-		filterServerFlagName = "filter[server]"
+		filterServerFlagName = "server"
 	} else {
-		filterServerFlagName = fmt.Sprintf("%v.filter[server]", cmdPrefix)
+		filterServerFlagName = fmt.Sprintf("%v.server", cmdPrefix)
 	}
 
 	var filterServerFlagDefault string
@@ -125,9 +125,9 @@ func registerOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilt
 
 	var filterVidFlagName string
 	if cmdPrefix == "" {
-		filterVidFlagName = "filter[vid]"
+		filterVidFlagName = "vid"
 	} else {
-		filterVidFlagName = fmt.Sprintf("%v.filter[vid]", cmdPrefix)
+		filterVidFlagName = fmt.Sprintf("%v.vid", cmdPrefix)
 	}
 
 	var filterVidFlagDefault string
@@ -142,9 +142,9 @@ func registerOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilt
 
 	var filterVirtualNetworkIdFlagName string
 	if cmdPrefix == "" {
-		filterVirtualNetworkIdFlagName = "filter[virtual_network_id]"
+		filterVirtualNetworkIdFlagName = "virtual_network_id"
 	} else {
-		filterVirtualNetworkIdFlagName = fmt.Sprintf("%v.filter[virtual_network_id]", cmdPrefix)
+		filterVirtualNetworkIdFlagName = fmt.Sprintf("%v.virtual_network_id", cmdPrefix)
 	}
 
 	var filterVirtualNetworkIdFlagDefault string
@@ -176,13 +176,13 @@ func retrieveOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsAPIV
 }
 func retrieveOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilterServerFlag(m *virtual_network_assignments.GetVirtualNetworksAssignmentsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[server]") {
+	if cmd.Flags().Changed("server") {
 
 		var filterServerFlagName string
 		if cmdPrefix == "" {
-			filterServerFlagName = "filter[server]"
+			filterServerFlagName = "server"
 		} else {
-			filterServerFlagName = fmt.Sprintf("%v.filter[server]", cmdPrefix)
+			filterServerFlagName = fmt.Sprintf("%v.server", cmdPrefix)
 		}
 
 		filterServerFlagValue, err := cmd.Flags().GetString(filterServerFlagName)
@@ -196,13 +196,13 @@ func retrieveOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilt
 }
 func retrieveOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilterVidFlag(m *virtual_network_assignments.GetVirtualNetworksAssignmentsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[vid]") {
+	if cmd.Flags().Changed("vid") {
 
 		var filterVidFlagName string
 		if cmdPrefix == "" {
-			filterVidFlagName = "filter[vid]"
+			filterVidFlagName = "vid"
 		} else {
-			filterVidFlagName = fmt.Sprintf("%v.filter[vid]", cmdPrefix)
+			filterVidFlagName = fmt.Sprintf("%v.vid", cmdPrefix)
 		}
 
 		filterVidFlagValue, err := cmd.Flags().GetString(filterVidFlagName)
@@ -216,13 +216,13 @@ func retrieveOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilt
 }
 func retrieveOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsFilterVirtualNetworkIDFlag(m *virtual_network_assignments.GetVirtualNetworksAssignmentsParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[virtual_network_id]") {
+	if cmd.Flags().Changed("virtual_network_id") {
 
 		var filterVirtualNetworkIdFlagName string
 		if cmdPrefix == "" {
-			filterVirtualNetworkIdFlagName = "filter[virtual_network_id]"
+			filterVirtualNetworkIdFlagName = "virtual_network_id"
 		} else {
-			filterVirtualNetworkIdFlagName = fmt.Sprintf("%v.filter[virtual_network_id]", cmdPrefix)
+			filterVirtualNetworkIdFlagName = fmt.Sprintf("%v.virtual_network_id", cmdPrefix)
 		}
 
 		filterVirtualNetworkIdFlagValue, err := cmd.Flags().GetString(filterVirtualNetworkIdFlagName)

--- a/cli/get_virtual_networks_operation.go
+++ b/cli/get_virtual_networks_operation.go
@@ -102,9 +102,9 @@ func registerOperationVirtualNetworksGetVirtualNetworksFilterLocationParamFlags(
 
 	var filterLocationFlagName string
 	if cmdPrefix == "" {
-		filterLocationFlagName = "filter[location]"
+		filterLocationFlagName = "location"
 	} else {
-		filterLocationFlagName = fmt.Sprintf("%v.filter[location]", cmdPrefix)
+		filterLocationFlagName = fmt.Sprintf("%v.location", cmdPrefix)
 	}
 
 	var filterLocationFlagDefault string
@@ -119,9 +119,9 @@ func registerOperationVirtualNetworksGetVirtualNetworksFilterProjectParamFlags(c
 
 	var filterProjectFlagName string
 	if cmdPrefix == "" {
-		filterProjectFlagName = "filter[project]"
+		filterProjectFlagName = "project"
 	} else {
-		filterProjectFlagName = fmt.Sprintf("%v.filter[project]", cmdPrefix)
+		filterProjectFlagName = fmt.Sprintf("%v.project", cmdPrefix)
 	}
 
 	var filterProjectFlagDefault string
@@ -153,13 +153,13 @@ func retrieveOperationVirtualNetworksGetVirtualNetworksAPIVersionFlag(m *virtual
 }
 func retrieveOperationVirtualNetworksGetVirtualNetworksFilterLocationFlag(m *virtual_networks.GetVirtualNetworksParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[location]") {
+	if cmd.Flags().Changed("location") {
 
 		var filterLocationFlagName string
 		if cmdPrefix == "" {
-			filterLocationFlagName = "filter[location]"
+			filterLocationFlagName = "location"
 		} else {
-			filterLocationFlagName = fmt.Sprintf("%v.filter[location]", cmdPrefix)
+			filterLocationFlagName = fmt.Sprintf("%v.location", cmdPrefix)
 		}
 
 		filterLocationFlagValue, err := cmd.Flags().GetString(filterLocationFlagName)
@@ -173,13 +173,13 @@ func retrieveOperationVirtualNetworksGetVirtualNetworksFilterLocationFlag(m *vir
 }
 func retrieveOperationVirtualNetworksGetVirtualNetworksFilterProjectFlag(m *virtual_networks.GetVirtualNetworksParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
-	if cmd.Flags().Changed("filter[project]") {
+	if cmd.Flags().Changed("project") {
 
 		var filterProjectFlagName string
 		if cmdPrefix == "" {
-			filterProjectFlagName = "filter[project]"
+			filterProjectFlagName = "project"
 		} else {
-			filterProjectFlagName = fmt.Sprintf("%v.filter[project]", cmdPrefix)
+			filterProjectFlagName = fmt.Sprintf("%v.project", cmdPrefix)
 		}
 
 		filterProjectFlagValue, err := cmd.Flags().GetString(filterProjectFlagName)

--- a/client/plans/get_plans_parameters.go
+++ b/client/plans/get_plans_parameters.go
@@ -109,7 +109,9 @@ type GetPlansParams struct {
 	                            [gte] to filter for values greater or equal to the provided value.
 	                            [lte] to filter by values lower or equal to the provided value.
 	*/
-	FilterRAM *int64
+	FilterRAMEql *int64
+	FilterRAMLte *int64
+	FilterRAMGte *int64
 
 	/* FilterSlug.
 
@@ -253,15 +255,37 @@ func (o *GetPlansParams) SetFilterName(filterName *string) {
 	o.FilterName = filterName
 }
 
-// WithFilterRAM adds the filterRAM to the get plans params
-func (o *GetPlansParams) WithFilterRAM(filterRAM *int64) *GetPlansParams {
-	o.SetFilterRAM(filterRAM)
+// WithFilterRAMEql adds the filterRAMEql to the get plans params
+func (o *GetPlansParams) WithFilterRAMEql(filterRAMEql *int64) *GetPlansParams {
+	o.SetFilterRAMEql(filterRAMEql)
 	return o
 }
 
-// SetFilterRAM adds the filterRam to the get plans params
-func (o *GetPlansParams) SetFilterRAM(filterRAM *int64) {
-	o.FilterRAM = filterRAM
+// SetFilterRAMEql adds the filterRamEql to the get plans params
+func (o *GetPlansParams) SetFilterRAMEql(filterRAMEql *int64) {
+	o.FilterRAMEql = filterRAMEql
+}
+
+// WithFilterRAMLte adds the filterRAMLte to the get plans params
+func (o *GetPlansParams) WithFilterRAMLte(filterRAMLte *int64) *GetPlansParams {
+	o.SetFilterRAMLte(filterRAMLte)
+	return o
+}
+
+// SetFilterRAMLte adds the filterRamLte to the get plans params
+func (o *GetPlansParams) SetFilterRAMLte(filterRAMLte *int64) {
+	o.FilterRAMLte = filterRAMLte
+}
+
+// WithFilterRAMGte adds the filterRAMGte to the get plans params
+func (o *GetPlansParams) WithFilterRAMGte(filterRAMGte *int64) *GetPlansParams {
+	o.SetFilterRAMGte(filterRAMGte)
+	return o
+}
+
+// SetFilterRAMGte adds the filterRamGte to the get plans params
+func (o *GetPlansParams) SetFilterRAMGte(filterRAMGte *int64) {
+	o.FilterRAMGte = filterRAMGte
 }
 
 // WithFilterSlug adds the filterSlug to the get plans params
@@ -421,18 +445,50 @@ func (o *GetPlansParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		}
 	}
 
-	if o.FilterRAM != nil {
+	if o.FilterRAMEql != nil {
 
-		// query param filter[ram]
-		var qrFilterRAM int64
+		// query param filter[ram][eql]
+		var qrFilterRAMEql int64
 
-		if o.FilterRAM != nil {
-			qrFilterRAM = *o.FilterRAM
+		if o.FilterRAMEql != nil {
+			qrFilterRAMEql = *o.FilterRAMEql
 		}
-		qFilterRAM := swag.FormatInt64(qrFilterRAM)
-		if qFilterRAM != "" {
+		qFilterRAMEql := swag.FormatInt64(qrFilterRAMEql)
+		if qFilterRAMEql != "" {
 
-			if err := r.SetQueryParam("filter[ram]", qFilterRAM); err != nil {
+			if err := r.SetQueryParam("filter[ram][eql]", qFilterRAMEql); err != nil {
+				return err
+			}
+		}
+	}
+	if o.FilterRAMLte != nil {
+
+		// query param filter[ram][lte]
+		var qrFilterRAMLte int64
+
+		if o.FilterRAMLte != nil {
+			qrFilterRAMLte = *o.FilterRAMLte
+		}
+		qFilterRAMLte := swag.FormatInt64(qrFilterRAMLte)
+		if qFilterRAMLte != "" {
+
+			if err := r.SetQueryParam("filter[ram][eql]", qFilterRAMLte); err != nil {
+				return err
+			}
+		}
+	}
+	if o.FilterRAMGte != nil {
+
+		// query param filter[ram][gte]
+		var qrFilterRAMGte int64
+
+		if o.FilterRAMGte != nil {
+			qrFilterRAMGte = *o.FilterRAMGte
+		}
+		qFilterRAMGte := swag.FormatInt64(qrFilterRAMGte)
+		if qFilterRAMGte != "" {
+
+			if err := r.SetQueryParam("filter[ram][gte]", qFilterRAMGte); err != nil {
 				return err
 			}
 		}

--- a/client/plans/get_plans_parameters.go
+++ b/client/plans/get_plans_parameters.go
@@ -74,7 +74,9 @@ type GetPlansParams struct {
 	                            [gte] to filter for values greater or equal to the provided value.
 	                            [lte] to filter by values lower or equal to the provided value.
 	*/
-	FilterDisk *int64
+	FilterDiskEql *int64
+	FilterDiskLte *int64
+	FilterDiskGte *int64
 
 	/* FilterGpu.
 
@@ -196,15 +198,15 @@ func (o *GetPlansParams) SetAPIVersion(aPIVersion *string) {
 	o.APIVersion = aPIVersion
 }
 
-// WithFilterDisk adds the filterDisk to the get plans params
-func (o *GetPlansParams) WithFilterDisk(filterDisk *int64) *GetPlansParams {
-	o.SetFilterDisk(filterDisk)
+// WithFilterDiskEql adds the filterDiskEql to the get plans params
+func (o *GetPlansParams) WithFilterDiskEql(filterDiskEql *int64) *GetPlansParams {
+	o.SetFilterDiskEql(filterDiskEql)
 	return o
 }
 
-// SetFilterDisk adds the filterDisk to the get plans params
-func (o *GetPlansParams) SetFilterDisk(filterDisk *int64) {
-	o.FilterDisk = filterDisk
+// SetFilterDiskEql adds the filterDiskEql to the get plans params
+func (o *GetPlansParams) SetFilterDiskEql(filterDiskEql *int64) {
+	o.FilterDiskEql = filterDiskEql
 }
 
 // WithFilterGpu adds the filterGpu to the get plans params
@@ -300,18 +302,52 @@ func (o *GetPlansParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		}
 	}
 
-	if o.FilterDisk != nil {
+	if o.FilterDiskEql != nil {
 
-		// query param filter[disk]
-		var qrFilterDisk int64
+		// query param filter[disk][eql]
+		var qrFilterDiskEql int64
 
-		if o.FilterDisk != nil {
-			qrFilterDisk = *o.FilterDisk
+		if o.FilterDiskEql != nil {
+			qrFilterDiskEql = *o.FilterDiskEql
 		}
-		qFilterDisk := swag.FormatInt64(qrFilterDisk)
-		if qFilterDisk != "" {
+		qFilterDiskEql := swag.FormatInt64(qrFilterDiskEql)
+		if qFilterDiskEql != "" {
 
-			if err := r.SetQueryParam("filter[disk]", qFilterDisk); err != nil {
+			if err := r.SetQueryParam("filter[disk][eql]", qFilterDiskEql); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.FilterDiskLte != nil {
+
+		// query param filter[disk][lte]
+		var qrFilterDiskLte int64
+
+		if o.FilterDiskLte != nil {
+			qrFilterDiskLte = *o.FilterDiskLte
+		}
+		qFilterDiskLte := swag.FormatInt64(qrFilterDiskLte)
+		if qFilterDiskLte != "" {
+
+			if err := r.SetQueryParam("filter[disk][lte]", qFilterDiskLte); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.FilterDiskGte != nil {
+
+		// query param filter[disk][gte]
+		var qrFilterDiskGte int64
+
+		if o.FilterDiskGte != nil {
+			qrFilterDiskGte = *o.FilterDiskGte
+		}
+		qFilterDiskGte := swag.FormatInt64(qrFilterDiskGte)
+		if qFilterDiskGte != "" {
+
+			if err := r.SetQueryParam("filter[disk][gte]", qFilterDiskGte); err != nil {
 				return err
 			}
 		}

--- a/client/servers/get_servers_parameters.go
+++ b/client/servers/get_servers_parameters.go
@@ -92,7 +92,9 @@ type GetServersParams struct {
 	                            [gte] to filter for values greater or equal to the provided value.
 	                            [lte] to filter by values lower or equal to the provided value.
 	*/
-	FilterDisk *int64
+	FilterDiskEql *int64
+	FilterDiskLte *int64
+	FilterDiskGte *int64
 
 	/* FilterGpu.
 
@@ -268,15 +270,37 @@ func (o *GetServersParams) SetFilterCreatedAtLte(filterCreatedAtLte *string) {
 	o.FilterCreatedAtLte = filterCreatedAtLte
 }
 
-// WithFilterDisk adds the filterDisk to the get servers params
-func (o *GetServersParams) WithFilterDisk(filterDisk *int64) *GetServersParams {
-	o.SetFilterDisk(filterDisk)
+// WithFilterDiskEql adds the filterDiskEql to the get servers params
+func (o *GetServersParams) WithFilterDiskEql(filterDiskEql *int64) *GetServersParams {
+	o.SetFilterDiskEql(filterDiskEql)
 	return o
 }
 
-// SetFilterDisk adds the filterDisk to the get servers params
-func (o *GetServersParams) SetFilterDisk(filterDisk *int64) {
-	o.FilterDisk = filterDisk
+// WithFilterDiskLte adds the filterDiskLte to the get servers params
+func (o *GetServersParams) WithFilterDiskLte(filterDiskLte *int64) *GetServersParams {
+	o.SetFilterDiskLte(filterDiskLte)
+	return o
+}
+
+// WithFilterDiskGte adds the filterDiskGte to the get servers params
+func (o *GetServersParams) WithFilterDiskGte(filterDiskGte *int64) *GetServersParams {
+	o.SetFilterDiskGte(filterDiskGte)
+	return o
+}
+
+// SetFilterDiskEql adds the filterDiskEql to the get servers params
+func (o *GetServersParams) SetFilterDiskEql(filterDiskEql *int64) {
+	o.FilterDiskEql = filterDiskEql
+}
+
+// SetFilterDiskLte adds the filterDiskLte to the get servers params
+func (o *GetServersParams) SetFilterDiskLte(filterDiskLte *int64) {
+	o.FilterDiskLte = filterDiskLte
+}
+
+// SetFilterDiskGte adds the filterDiskGte to the get servers params
+func (o *GetServersParams) SetFilterDiskGte(filterDiskGte *int64) {
+	o.FilterDiskGte = filterDiskGte
 }
 
 // WithFilterGpu adds the filterGpu to the get servers params
@@ -467,18 +491,52 @@ func (o *GetServersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		}
 	}
 
-	if o.FilterDisk != nil {
+	if o.FilterDiskEql != nil {
 
 		// query param filter[disk]
-		var qrFilterDisk int64
+		var qrFilterDiskEql int64
 
-		if o.FilterDisk != nil {
-			qrFilterDisk = *o.FilterDisk
+		if o.FilterDiskEql != nil {
+			qrFilterDiskEql = *o.FilterDiskEql
 		}
-		qFilterDisk := swag.FormatInt64(qrFilterDisk)
-		if qFilterDisk != "" {
+		qFilterDiskEql := swag.FormatInt64(qrFilterDiskEql)
+		if qFilterDiskEql != "" {
 
-			if err := r.SetQueryParam("filter[disk]", qFilterDisk); err != nil {
+			if err := r.SetQueryParam("filter[disk][eql]", qFilterDiskEql); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.FilterDiskLte != nil {
+
+		// query param filter[disk]
+		var qrFilterDiskLte int64
+
+		if o.FilterDiskLte != nil {
+			qrFilterDiskLte = *o.FilterDiskLte
+		}
+		qFilterDiskLte := swag.FormatInt64(qrFilterDiskLte)
+		if qFilterDiskLte != "" {
+
+			if err := r.SetQueryParam("filter[disk][lte]", qFilterDiskLte); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.FilterDiskGte != nil {
+
+		// query param filter[disk]
+		var qrFilterDiskGte int64
+
+		if o.FilterDiskGte != nil {
+			qrFilterDiskGte = *o.FilterDiskGte
+		}
+		qFilterDiskGte := swag.FormatInt64(qrFilterDiskGte)
+		if qFilterDiskGte != "" {
+
+			if err := r.SetQueryParam("filter[disk][gte]", qFilterDiskGte); err != nil {
 				return err
 			}
 		}

--- a/client/virtual_network_assignments/assign_server_virtual_network_responses.go
+++ b/client/virtual_network_assignments/assign_server_virtual_network_responses.go
@@ -511,11 +511,11 @@ type AssignServerVirtualNetworkParamsBodyDataAttributes struct {
 
 	// server id
 	// Required: true
-	ServerID *int64 `json:"server_id"`
+	ServerID string `json:"server_id"`
 
 	// virtual network id
 	// Required: true
-	VirtualNetworkID *int64 `json:"virtual_network_id"`
+	VirtualNetworkID string `json:"virtual_network_id"`
 }
 
 // Validate validates this assign server virtual network params body data attributes


### PR DESCRIPTION
### What

This PR changes the filters format from `--filter[attr] value` to `--attr value`. For composed filters, we decided to add a `_` as a separator, like `--ram_lte 32`.

With that, we should no longer see issues with brackets on different shells.

### How to test

Below, I'm going to list each filter individually to make the tests easier, but consider also combining filters for a more effective test.

- Run `go build -o lsh cmd/lsh/main.go`

#### Plans

`./lsh plans list --disk_eql 1000`
`./lsh plans list --disk_gte 1000`
`./lsh plans list --disk_lte 1000`
`./lsh plans list --gpu true`
`./lsh plans list --in_stock true`
`./lsh plans list --location SAO`
`./lsh plans list --name c3.xlarge.x86`
`./lsh plans list --ram_eql 32`
`./lsh plans list --ram_gte 32`
`./lsh plans list --ram_lte 32`
`./lsh plans list --slug c3-xlarge-x86`
`./lsh plans list --stock_level Medium`


#### Projects

`./lsh projects list --billing_type Custom`
`./lsh projects list --description "My project description"`
`./lsh projects list --environment Staging`
`./lsh projects list --name QA`
`./lsh projects list --slug qa`

#### Servers

`./lsh servers list --created_at_gte DATE`
`./lsh servers list --created_at_lte DATE`
`./lsh servers list --disk_eql 1000`
`./lsh servers list --disk_gte 1000`
`./lsh servers list --disk_lte 1000`
`./lsh servers list --gpu true`
`./lsh servers list --ram_eql 32`
`./lsh servers list --ram_gte 32`
`./lsh servers list --ram_lte 32`
`./lsh servers list --hostname HOSTNAME`
`./lsh servers list --label LABEL`
`./lsh servers list --operating_system ubuntu_20_04_x64_lts`
`./lsh servers list --plan c3.xlarge.x86`
`./lsh servers list --project qa`
`./lsh servers list --region SAO`
`./lsh servers list --status Normal`

#### SSH Keys

`./lsh ssh_keys list --project_id_or_slug qa`

#### Virtual Networks

`./lsh ssh_keys list --location SAO`
`./lsh ssh_keys list --project qa`