### PR TITLE
Feat: Improvements to versioning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
   - main: ./cmd/lsh/main.go
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -X "github.com/latitudesh/lsh/internal/version.Version={{ .Tag }}"
     goos:
       - linux
       - windows

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/latitudesh/lsh/client"
+	"github.com/latitudesh/lsh/internal/version"
 
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
@@ -77,10 +78,9 @@ func MakeRootCmd() (*cobra.Command, error) {
 	cobra.OnInitialize(initViperConfigs)
 
 	// Use executable name as the command name
-	// FIXED Version, must be updated when pushing a new tag
 	rootCmd := &cobra.Command{
 		Use: exeName,
-		Version: "v0.0.1",
+		Version: version.Version,
 	}
 
 	// Edit commands template

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -77,9 +77,14 @@ func MakeRootCmd() (*cobra.Command, error) {
 	cobra.OnInitialize(initViperConfigs)
 
 	// Use executable name as the command name
+	// FIXED Version, must be updated when pushing a new tag
 	rootCmd := &cobra.Command{
 		Use: exeName,
+		Version: "v0.0.1",
 	}
+
+	// Edit commands template
+	rootCmd.SetVersionTemplate(fmt.Sprintf("lsh %s\n", rootCmd.Version))
 
 	// register basic flags
 	rootCmd.PersistentFlags().String("hostname", client.DefaultHost, "hostname of the service")

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-openapi/swag v0.22.7
 	github.com/go-openapi/validate v0.22.6
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 )
@@ -32,7 +33,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ FILENAME=$(printf "$BASE_FILENAME" "$OS" "$ARCH")
 LATEST=$(curl -L -s \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/latitudesh/lsh/releases/latest | grep "tag_name" |cut -d "\"" -f 4)
+    https://api.github.com/repos/latitudesh/lsh/releases/latest | grep "tag_name" | cut -d "\"" -f 4)
 
 URL="https://github.com/latitudesh/lsh/releases/download/$LATEST/$FILENAME.tar.gz"
 

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,14 @@ OS=$(uname -s)
 ARCH=$(uname -m)
 BASE_FILENAME="lsh_%s_%s"
 FILENAME=$(printf "$BASE_FILENAME" "$OS" "$ARCH")
-STABLE_VERSION=v0.0.1
-URL="https://github.com/latitudesh/lsh/releases/download/$STABLE_VERSION/$FILENAME.tar.gz"
+
+# The latest release will be the most recent non-prerelease, non-draft release.
+LATEST=$(curl -L -s \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/latitudesh/lsh/releases/latest | grep "tag_name" |cut -d "\"" -f 4)
+
+URL="https://github.com/latitudesh/lsh/releases/download/$LATEST/$FILENAME.tar.gz"
 
 echo -e "[lsh] Download started!\n"
 curl -L -o lsh.tar.gz $URL

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the current version of the lsh CLI.
+// it is updated automatically by goreleaser, and should not be manually set.
+var Version = "v0.0.0"


### PR DESCRIPTION
### What does this PR do?
This PR aims to improve the cli versioning

### How
- Modify our Install Script to fetch the latest release version that is not a pre-release or a draft release
- Add `--version` and `-v` tags to the CLI so users can fetch the actual cli version
- Set the CLI version when pushing a new release

To further explain this last point, every time we push a tag to github, ghActions will be triggered to publish a new release. One of our ghAction steps is `Goreleaser`, an application made to facilitate building and releasing go binaries for multiple platforms.

In our GoReleaser file we are looking for a module called `github.com/latitudesh/lsh/internal/version` and setting it's variable `Version` to the github tag that trigerred the release before the building step.

This way the CLI will always know which version it is in, without developers having to manually change it

### Why use a separate file for the `Version` variable
As this file will be modified by our build steps, it is a good practice to separate it from code that can affect the functionality of the cli, to avoid unexpected changes.

#### How to Test
You can install the cli with the installation script and verify if it works.
Also, you can test the version flag by building the cli locally and running:

```
./lsh --version
# or
./lsh -v
```

The above command should return `lsh v0.0.0`.

To test the automatically set `Version` variable you will need to download goreleaser OSS version (https://goreleaser.com/install/) .
After that you can run it in your folder by using:

```
goreleaser release --snapshot --skip=publish --clean
```

this should generate a folder named dist with the release files, then run:

```
./dist/lsh_<PLATFORM_ARCH>/lsh -v
```

this should return the latest tag we've pushed as the version, which is `lsh v0.0.1` as of now.

