### PR TITLE
[Fix] Add proper message for empty lists

### DIFF
--- a/client/api_keys/get_api_keys_responses.go
+++ b/client/api_keys/get_api_keys_responses.go
@@ -141,6 +141,11 @@ func (o *GetAPIKeysOK) RenderJSON() {
 }
 
 func (o *GetAPIKeysOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	data := o.Payload.Data
 
 	var rows []APIKeyTableRow

--- a/client/plans/get_bandwidth_plans_responses.go
+++ b/client/plans/get_bandwidth_plans_responses.go
@@ -133,6 +133,11 @@ func (o *GetBandwidthPlansOK) RenderJSON() {
 }
 
 func (o *GetBandwidthPlansOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	rows := tablerows.CreateBandwidthPlanRows(o.Payload.Data)
 	table.Render(rows)
 }

--- a/client/plans/get_plans_responses.go
+++ b/client/plans/get_plans_responses.go
@@ -148,6 +148,11 @@ func (o *GetPlansOK) RenderJSON() {
 }
 
 func (o *GetPlansOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	rows := tablerows.CreatePlanRows(o.Payload.Data)
 	table.Render(rows)
 }

--- a/client/projects/get_projects_responses.go
+++ b/client/projects/get_projects_responses.go
@@ -133,6 +133,11 @@ func (o *GetProjectsOK) RenderJSON() {
 }
 
 func (o *GetProjectsOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	rows := tablerows.CreateProjectRows(o.Payload.Data)
 	table.Render(rows)
 }

--- a/client/servers/get_servers_responses.go
+++ b/client/servers/get_servers_responses.go
@@ -133,6 +133,11 @@ func (o *GetServersOK) RenderJSON() {
 }
 
 func (o *GetServersOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	rows := tablerows.CreateServerRows(o.Payload.Data)
 	table.Render(rows)
 }

--- a/client/ssh_keys/get_project_ssh_keys_responses.go
+++ b/client/ssh_keys/get_project_ssh_keys_responses.go
@@ -139,6 +139,11 @@ func (o *GetProjectSSHKeysOK) RenderJSON() {
 }
 
 func (o *GetProjectSSHKeysOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	rows := tablerows.CreateSSHKeyRows(o.Payload.Data)
 	table.Render(rows)
 }

--- a/client/virtual_network_assignments/get_virtual_networks_assignments_responses.go
+++ b/client/virtual_network_assignments/get_virtual_networks_assignments_responses.go
@@ -135,6 +135,11 @@ func (o *GetVirtualNetworksAssignmentsOK) RenderJSON() {
 }
 
 func (o *GetVirtualNetworksAssignmentsOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	rows := tablerows.CreateVirtualNetworkAssignmentsRows(o.Payload.Data)
 	table.Render(rows)
 }

--- a/client/virtual_networks/get_virtual_networks_responses.go
+++ b/client/virtual_networks/get_virtual_networks_responses.go
@@ -135,6 +135,11 @@ func (o *GetVirtualNetworksOK) RenderJSON() {
 }
 
 func (o *GetVirtualNetworksOK) RenderTable() {
+	if len(o.Payload.Data) == 0 {
+		table.RenderEmptyState("No results found.")
+		return
+	}
+
 	rows := tablerows.CreateVirtualNetworksRows(o.Payload.Data)
 	table.Render(rows)
 }

--- a/internal/output/table/utils.go
+++ b/internal/output/table/utils.go
@@ -42,6 +42,17 @@ func Render(rows []interface{}) {
 	render(Table{Headers: headers, Rows: values})
 }
 
+func RenderEmptyState(message string) {
+	table := tablewriter.NewWriter(os.Stdout)
+
+	table.SetRowLine(true)
+	table.Append([]string{message})
+
+	fmt.Println()
+	table.Render()
+	fmt.Println()
+}
+
 func render(table Table) {
 	tableWriter := tablewriter.NewWriter(os.Stdout)
 


### PR DESCRIPTION
### What

Currently, when a `list` command returns empty results, the table output crashes. This PR adds a guard-clause to early return a message when the response has no results.

### How to test

Force an empty result by passing invalid arguments to the list command, for example:

```

lsh servers list --hostname invalid
```

- [ ] It should return a message indicating that no results have been found