### PR TITLE
feat: update command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -121,6 +121,12 @@ func MakeRootCmd() (*cobra.Command, error) {
 	}
 	rootCmd.AddCommand(operationLoginCmd)
 
+	operationUpdateCmd, err := makeOperationUpdateCmd()
+	if err != nil {
+		return nil, err
+	}
+	rootCmd.AddCommand(operationUpdateCmd)
+
 	operationGroupAPIKeysCmd, err := makeOperationGroupAPIKeysCmd()
 	if err != nil {
 		return nil, err

--- a/cli/update.go
+++ b/cli/update.go
@@ -27,22 +27,35 @@ func makeOperationUpdateCmd() (*cobra.Command, error) {
 }
 
 func runOperationUpdate(cmd *cobra.Command, args []string) error {
-	release, err := updater.LatestLshRelease()
+	latestVersion, err := verifyLatestVersion()
 	if err != nil {
 		return err
+	}
+
+	if latestVersion == "" {
+		log.Println("Already at the latest version.")
+		return nil
+	}
+
+	err = updater.Update(latestVersion)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyLatestVersion() (string, error) {
+	release, err := updater.LatestLshRelease()
+	if err != nil {
+		return "", err
 	}
 
 	releaseVersion := release.TagName
 
 	if releaseVersion == version.Version {
-		log.Println("Already at the latest version.")
-		return nil
+		return "", nil
 	}
 
 	log.Printf("New version found: %s", releaseVersion)
-	err = updater.Update(releaseVersion)
-	if err != nil {
-		return err
-	}
-	return nil
+	return releaseVersion, nil
 }

--- a/cli/update.go
+++ b/cli/update.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"log"
 	"runtime"
 
@@ -36,7 +35,8 @@ func runOperationUpdate(cmd *cobra.Command, args []string) error {
 	releaseVersion := release.TagName
 
 	if releaseVersion == version.Version {
-		return fmt.Errorf("already at the latest version")
+		log.Println("Already at the latest version.")
+		return nil
 	}
 
 	log.Printf("New version found: %s", releaseVersion)

--- a/cli/update.go
+++ b/cli/update.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"fmt"
+	"log"
 	"runtime"
 
 	"github.com/latitudesh/lsh/internal/updater"
+	"github.com/latitudesh/lsh/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +28,19 @@ func makeOperationUpdateCmd() (*cobra.Command, error) {
 }
 
 func runOperationUpdate(cmd *cobra.Command, args []string) error {
-	err := updater.Update()
+	release, err := updater.LatestLshRelease()
+	if err != nil {
+		return err
+	}
+
+	releaseVersion := release.TagName
+
+	if releaseVersion == version.Version {
+		return fmt.Errorf("already at the latest version")
+	}
+
+	log.Printf("New version found: %s", releaseVersion)
+	err = updater.Update(releaseVersion)
 	if err != nil {
 		return err
 	}

--- a/cli/update.go
+++ b/cli/update.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"runtime"
+
+	"github.com/latitudesh/lsh/internal/updater"
+	"github.com/spf13/cobra"
+)
+
+const (
+	OS   = runtime.GOOS
+	ARCH = runtime.GOARCH
+)
+
+func makeOperationUpdateCmd() (*cobra.Command, error) {
+	// updateCmd represents the update command
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update the CLI to latest version",
+		Long:  `update will verify if a new version is out and update the cli to it.`,
+		RunE:  runOperationUpdate,
+	}
+
+	return cmd, nil
+}
+
+func runOperationUpdate(cmd *cobra.Command, args []string) error {
+	err := updater.Update()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
+	golang.org/x/text v0.14.0
 )
 
 require (
@@ -50,8 +51,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/updater/file_actions.go
+++ b/internal/updater/file_actions.go
@@ -1,0 +1,117 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+const (
+	OS   = runtime.GOOS
+	ARCH = runtime.GOARCH
+)
+
+// downloadFile Downloads file from the given url and saves to filepath
+func downloadFile(filepath string, url string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+// buildFileName gets the correct fileName for your Operating system and archtecture
+func buildFilename() string {
+	caser := cases.Title(language.English)
+	os := caser.String(OS)
+
+	arch := parseArch(ARCH)
+
+	return fmt.Sprintf("lsh_%s_%s", os, arch)
+}
+
+// parseArch expects a GOARCH and returns the arch in our github release format
+func parseArch(goArch string) string {
+	if goArch == "amd64" {
+		return "x86_64"
+	}
+	if goArch == "386" {
+		return "i386"
+	}
+
+	return goArch
+}
+
+// untarFile expects a io.Reader with the file and a path which it will untar to
+func untarFile(path string, r io.Reader) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		case err == io.EOF:
+			return nil
+
+		case err != nil:
+			return err
+
+		case header == nil:
+			continue
+		}
+
+		target := filepath.Join(path, header.Name)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+		case tar.TypeReg:
+			fileDir := filepath.Dir(target)
+
+			if err := os.MkdirAll(fileDir, 0770); err != nil {
+				return fmt.Errorf("untar failed while creating folder: %s", err.Error())
+			}
+			outFile, err := os.Create(target)
+			if err != nil {
+				return fmt.Errorf("untar failed while creating file: %s", err.Error())
+			}
+			err = os.Chmod(outFile.Name(), 0755)
+			if err != nil {
+				return fmt.Errorf("untar failed, permission error: %s", err.Error())
+			}
+			if _, err := io.Copy(outFile, tr); err != nil {
+				return fmt.Errorf("untar failed while copying data to file: %s", err.Error())
+
+			}
+			outFile.Close()
+		}
+	}
+}

--- a/internal/updater/file_actions.go
+++ b/internal/updater/file_actions.go
@@ -19,6 +19,26 @@ const (
 	ARCH = runtime.GOARCH
 )
 
+type UpdateFile struct {
+	Name      string
+	Dir       string
+	Extension string
+}
+
+func NewUpdateFile() *UpdateFile {
+	dir := buildDirName()
+	ext := buildExtesion(OS)
+	return &UpdateFile{
+		Name:      dir + ext,
+		Dir:       dir,
+		Extension: ext,
+	}
+}
+
+func (uf *UpdateFile) Url(version string) string {
+	return fmt.Sprintf("https://github.com/latitudesh/lsh/releases/download/%s/%s", version, uf.Name)
+}
+
 // downloadFile Downloads file from the given url and saves to filepath
 func downloadFile(filepath string, url string) error {
 	resp, err := http.Get(url)
@@ -38,13 +58,20 @@ func downloadFile(filepath string, url string) error {
 }
 
 // buildFileName builds the correct file name for your Operating system and architecture
-func buildFilename() string {
+func buildDirName() string {
 	caser := cases.Title(language.English)
 	os := caser.String(OS)
 
 	arch := parseArch(ARCH)
 
 	return fmt.Sprintf("lsh_%s_%s", os, arch)
+}
+
+func buildExtesion(os string) string {
+	if os == "windows" {
+		return ".zip"
+	}
+	return ".tar.gz"
 }
 
 // parseArch expects a GOARCH and returns the arch in our github release format

--- a/internal/updater/file_actions.go
+++ b/internal/updater/file_actions.go
@@ -37,7 +37,7 @@ func downloadFile(filepath string, url string) error {
 	return err
 }
 
-// buildFileName gets the correct fileName for your Operating system and archtecture
+// buildFileName builds the correct file name for your Operating system and architecture
 func buildFilename() string {
 	caser := cases.Title(language.English)
 	os := caser.String(OS)

--- a/internal/updater/github_release.go
+++ b/internal/updater/github_release.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 )
 
@@ -19,7 +18,7 @@ func LatestLshRelease() (*GithubRelease, error) {
 	release := GithubRelease{}
 	err := buildRelease("repos/latitudesh/lsh/releases/latest", &release)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	return &release, err
 }

--- a/internal/updater/github_release.go
+++ b/internal/updater/github_release.go
@@ -1,0 +1,59 @@
+package updater
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+// GithubRelease represents a release object from the Github API
+type GithubRelease struct {
+	Id      int    `json:"id"`
+	TagName string `json:"tag_name"`
+}
+
+// latestLshRelease returns the latest lsh CLI release
+func LatestLshRelease() (*GithubRelease, error) {
+	release := GithubRelease{}
+	err := buildRelease("repos/latitudesh/lsh/releases/latest", &release)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &release, err
+}
+
+// gitHubRequest accepts a method, path and a client to execute a github request
+func gitHubRequest(method, path string, client *http.Client) (string, error) {
+	req, _ := http.NewRequest(method, fmt.Sprintf("https://api.github.com/%s", path), nil)
+	req.Header = http.Header{
+		"Accept":               {"application/vnd.github+json"},
+		"X-GitHub-Api-Version": {"2022-11-28"},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// buildRelease Unmarshals github information into a release object
+func buildRelease(url string, release *GithubRelease) error {
+	resp, err := gitHubRequest("GET", url, &http.Client{})
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal([]byte(resp), release)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/updater/github_release.go
+++ b/internal/updater/github_release.go
@@ -23,6 +23,19 @@ func LatestLshRelease() (*GithubRelease, error) {
 	return &release, err
 }
 
+// buildRelease Unmarshals github information into a release object
+func buildRelease(url string, release *GithubRelease) error {
+	resp, err := gitHubRequest("GET", url, &http.Client{})
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal([]byte(resp), release)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // gitHubRequest accepts a method, path and a client to execute a github request
 func gitHubRequest(method, path string, client *http.Client) (string, error) {
 	req, _ := http.NewRequest(method, fmt.Sprintf("https://api.github.com/%s", path), nil)
@@ -42,17 +55,4 @@ func gitHubRequest(method, path string, client *http.Client) (string, error) {
 	}
 
 	return string(body), nil
-}
-
-// buildRelease Unmarshals github information into a release object
-func buildRelease(url string, release *GithubRelease) error {
-	resp, err := gitHubRequest("GET", url, &http.Client{})
-	if err != nil {
-		return err
-	}
-	err = json.Unmarshal([]byte(resp), release)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -10,23 +10,22 @@ import (
 func Update(version string) error {
 	log.Println("Update started!")
 
+	updateFile := NewUpdateFile()
+
 	tempDir, err := os.MkdirTemp("", "temp")
 	if err != nil {
 		return err
 	}
-
-	filename := buildFilename()
-	downloadURL := fmt.Sprintf("https://github.com/latitudesh/lsh/releases/download/%s/%s.tar.gz", version, filename)
-	filePath := fmt.Sprintf("%s/%s.tar.gz", tempDir, filename)
+	DownloadPath := fmt.Sprintf("%s/%s", tempDir, updateFile.Name)
 
 	log.Println("Downloading new version...")
-	err = downloadFile(filePath, downloadURL)
+	err = downloadFile(DownloadPath, updateFile.Url(version))
 	if err != nil {
 		return err
 	}
 	log.Println("Download finished successfully!")
 
-	f, err := os.Open(fmt.Sprintf("%s/%s.tar.gz", tempDir, filename))
+	f, err := os.Open(fmt.Sprintf("%s/%s", tempDir, updateFile.Name))
 	if err != nil {
 		return err
 	}
@@ -42,7 +41,7 @@ func Update(version string) error {
 	}
 
 	oldExecPath := fmt.Sprintf("%s-old", currentExecPath)
-	newExecPath := fmt.Sprintf("%s/%s/lsh", tempDir, filename)
+	newExecPath := fmt.Sprintf("%s/%s/lsh", tempDir, updateFile.Dir)
 
 	// Rename current lsh binary to lsh-old
 	err = os.Rename(currentExecPath, oldExecPath)

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -1,0 +1,80 @@
+package updater
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/latitudesh/lsh/internal/version"
+)
+
+func Update() error {
+	log.Println("Update started!")
+
+	release, err := LatestLshRelease()
+	if err != nil {
+		return err
+	}
+
+	if release.TagName == version.Version {
+		log.Println()
+	}
+
+	tempDir, err := os.MkdirTemp("", "temp")
+	if err != nil {
+		return err
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	filename := buildFilename()
+	downloadURL := fmt.Sprintf("https://github.com/latitudesh/lsh/releases/download/%s/%s.tar.gz", release.TagName, filename)
+	filePath := fmt.Sprintf("%s/%s.tar.gz", tempDir, filename)
+
+	log.Println("Downloading new version...")
+	err = downloadFile(filePath, downloadURL)
+	if err != nil {
+		return err
+	}
+	log.Println("Download finished successfully!")
+
+	f, err := os.Open(fmt.Sprintf("%s/%s.tar.gz", tempDir, filename))
+	if err != nil {
+		return err
+	}
+
+	err = untarFile(tempDir, f)
+	if err != nil {
+		return err
+	}
+
+	currentBinPath := fmt.Sprintf("%s/.lsh/lsh", homeDir)
+	newBinPath := fmt.Sprintf("%s/%s/lsh", tempDir, filename)
+	oldBinPath := fmt.Sprintf("%s/.lsh/lsh-old", homeDir)
+
+	// Rename current lsh binary to lsh-old
+	err = os.Rename(currentBinPath, oldBinPath)
+	if err != nil {
+		return err
+	}
+
+	// Rename and move downloaded lsh binary
+	os.Rename(newBinPath, currentBinPath)
+	if err != nil {
+		return err
+	}
+
+	// Remove old binary
+	os.Remove(oldBinPath)
+	if err != nil {
+		return err
+	}
+
+	os.RemoveAll(tempDir)
+	log.Println("Update finished successfully!")
+
+	return nil
+}

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -1,9 +1,9 @@
 package updater
 
 import (
-	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 )
 
 // Update expects a version string and updates the cli to it
@@ -16,16 +16,16 @@ func Update(version string) error {
 	if err != nil {
 		return err
 	}
-	DownloadPath := fmt.Sprintf("%s/%s", tempDir, updateFile.Name)
+	destinationPath := filepath.Join(tempDir, updateFile.Name)
 
 	log.Println("Downloading new version...")
-	err = downloadFile(DownloadPath, updateFile.Url(version))
+	err = updateFile.Download(destinationPath, version)
 	if err != nil {
 		return err
 	}
 	log.Println("Download finished successfully!")
 
-	f, err := os.Open(fmt.Sprintf("%s/%s", tempDir, updateFile.Name))
+	f, err := os.Open(filepath.Join(tempDir, updateFile.Name))
 	if err != nil {
 		return err
 	}
@@ -40,8 +40,8 @@ func Update(version string) error {
 		return err
 	}
 
-	oldExecPath := fmt.Sprintf("%s-old", currentExecPath)
-	newExecPath := fmt.Sprintf("%s/%s/lsh", tempDir, updateFile.Dir)
+	oldExecPath := currentExecPath + "-old"
+	newExecPath := filepath.Join(tempDir, updateFile.Dir, "lsh")
 
 	// Rename current lsh binary to lsh-old
 	err = os.Rename(currentExecPath, oldExecPath)

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -4,21 +4,11 @@ import (
 	"fmt"
 	"log"
 	"os"
-
-	"github.com/latitudesh/lsh/internal/version"
 )
 
-func Update() error {
+// Update expects a version string and updates the cli to it
+func Update(version string) error {
 	log.Println("Update started!")
-
-	release, err := LatestLshRelease()
-	if err != nil {
-		return err
-	}
-
-	if release.TagName == version.Version {
-		log.Println()
-	}
 
 	tempDir, err := os.MkdirTemp("", "temp")
 	if err != nil {
@@ -31,7 +21,7 @@ func Update() error {
 	}
 
 	filename := buildFilename()
-	downloadURL := fmt.Sprintf("https://github.com/latitudesh/lsh/releases/download/%s/%s.tar.gz", release.TagName, filename)
+	downloadURL := fmt.Sprintf("https://github.com/latitudesh/lsh/releases/download/%s/%s.tar.gz", version, filename)
 	filePath := fmt.Sprintf("%s/%s.tar.gz", tempDir, filename)
 
 	log.Println("Downloading new version...")

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -15,11 +15,6 @@ func Update(version string) error {
 		return err
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
 	filename := buildFilename()
 	downloadURL := fmt.Sprintf("https://github.com/latitudesh/lsh/releases/download/%s/%s.tar.gz", version, filename)
 	filePath := fmt.Sprintf("%s/%s.tar.gz", tempDir, filename)
@@ -41,24 +36,28 @@ func Update(version string) error {
 		return err
 	}
 
-	currentBinPath := fmt.Sprintf("%s/.lsh/lsh", homeDir)
-	newBinPath := fmt.Sprintf("%s/%s/lsh", tempDir, filename)
-	oldBinPath := fmt.Sprintf("%s/.lsh/lsh-old", homeDir)
+	currentExecPath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	oldExecPath := fmt.Sprintf("%s-old", currentExecPath)
+	newExecPath := fmt.Sprintf("%s/%s/lsh", tempDir, filename)
 
 	// Rename current lsh binary to lsh-old
-	err = os.Rename(currentBinPath, oldBinPath)
+	err = os.Rename(currentExecPath, oldExecPath)
 	if err != nil {
 		return err
 	}
 
 	// Rename and move downloaded lsh binary
-	os.Rename(newBinPath, currentBinPath)
+	os.Rename(newExecPath, currentExecPath)
 	if err != nil {
 		return err
 	}
 
 	// Remove old binary
-	os.Remove(oldBinPath)
+	os.Remove(oldExecPath)
 	if err != nil {
 		return err
 	}

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/latitudesh/lsh/internal/utils"
 )
 
 // Update expects a version string and updates the cli to it
@@ -30,7 +32,7 @@ func Update(version string) error {
 		return err
 	}
 
-	err = untarFile(tempDir, f)
+	err = utils.Untar(tempDir, f)
 	if err != nil {
 		return err
 	}

--- a/internal/updater/update_file.go
+++ b/internal/updater/update_file.go
@@ -39,15 +39,14 @@ func (uf *UpdateFile) Url(version string) string {
 	return fmt.Sprintf("https://github.com/latitudesh/lsh/releases/download/%s/%s", version, uf.Name)
 }
 
-// downloadFile Downloads file from the given url and saves to filepath
-func downloadFile(filepath string, url string) error {
-	resp, err := http.Get(url)
+func (uf *UpdateFile) Download(dstPath, version string) error {
+	resp, err := http.Get(uf.Url(version))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
-	out, err := os.Create(filepath)
+	out, err := os.Create(dstPath)
 	if err != nil {
 		return err
 	}

--- a/internal/updater/update_file.go
+++ b/internal/updater/update_file.go
@@ -1,13 +1,10 @@
 package updater
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"runtime"
 
 	"golang.org/x/text/cases"
@@ -56,7 +53,7 @@ func (uf *UpdateFile) Download(dstPath, version string) error {
 	return err
 }
 
-// buildFileName builds the correct file name for your Operating system and architecture
+// buildDirName builds the correct file name for your Operating system and architecture
 func buildDirName() string {
 	caser := cases.Title(language.English)
 	os := caser.String(OS)
@@ -83,61 +80,4 @@ func parseArch(goArch string) string {
 	}
 
 	return goArch
-}
-
-// untarFile expects a io.Reader with the file and a path which it will untar to
-func untarFile(path string, r io.Reader) error {
-	gzr, err := gzip.NewReader(r)
-	if err != nil {
-		return err
-	}
-	defer gzr.Close()
-
-	tr := tar.NewReader(gzr)
-
-	for {
-		header, err := tr.Next()
-
-		switch {
-
-		case err == io.EOF:
-			return nil
-
-		case err != nil:
-			return err
-
-		case header == nil:
-			continue
-		}
-
-		target := filepath.Join(path, header.Name)
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if _, err := os.Stat(target); err != nil {
-				if err := os.MkdirAll(target, 0755); err != nil {
-					return err
-				}
-			}
-		case tar.TypeReg:
-			fileDir := filepath.Dir(target)
-
-			if err := os.MkdirAll(fileDir, 0770); err != nil {
-				return fmt.Errorf("untar failed while creating folder: %s", err.Error())
-			}
-			outFile, err := os.Create(target)
-			if err != nil {
-				return fmt.Errorf("untar failed while creating file: %s", err.Error())
-			}
-			err = os.Chmod(outFile.Name(), 0755)
-			if err != nil {
-				return fmt.Errorf("untar failed, permission error: %s", err.Error())
-			}
-			if _, err := io.Copy(outFile, tr); err != nil {
-				return fmt.Errorf("untar failed while copying data to file: %s", err.Error())
-
-			}
-			outFile.Close()
-		}
-	}
 }

--- a/internal/updater/update_file.go
+++ b/internal/updater/update_file.go
@@ -17,18 +17,22 @@ const (
 )
 
 type UpdateFile struct {
-	Name      string
-	Dir       string
-	Extension string
+	Name       string
+	Dir        string
+	Extension  string
+	Executable string
 }
 
 func NewUpdateFile() *UpdateFile {
 	dir := buildDirName()
 	ext := buildExtesion(OS)
+	exec := buildExecutableName(OS)
+
 	return &UpdateFile{
-		Name:      dir + ext,
-		Dir:       dir,
-		Extension: ext,
+		Dir:        buildDirName(),
+		Extension:  ext,
+		Name:       dir + ext,
+		Executable: exec,
 	}
 }
 
@@ -68,6 +72,13 @@ func buildExtesion(os string) string {
 		return ".zip"
 	}
 	return ".tar.gz"
+}
+
+func buildExecutableName(os string) string {
+	if os == "windows" {
+		return "lsh.exe"
+	}
+	return "lsh"
 }
 
 // parseArch expects a GOARCH and returns the arch in our github release format

--- a/internal/utils/file_utils.go
+++ b/internal/utils/file_utils.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Untar expects a io.Reader with the file and a path which it will untar to
+func Untar(path string, r io.Reader) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		case err == io.EOF:
+			return nil
+
+		case err != nil:
+			return err
+
+		case header == nil:
+			continue
+		}
+
+		target := filepath.Join(path, header.Name)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+		case tar.TypeReg:
+			fileDir := filepath.Dir(target)
+
+			if err := os.MkdirAll(fileDir, 0770); err != nil {
+				return fmt.Errorf("untar failed while creating folder: %s", err.Error())
+			}
+			outFile, err := os.Create(target)
+			if err != nil {
+				return fmt.Errorf("untar failed while creating file: %s", err.Error())
+			}
+			err = os.Chmod(outFile.Name(), 0755)
+			if err != nil {
+				return fmt.Errorf("untar failed, permission error: %s", err.Error())
+			}
+			if _, err := io.Copy(outFile, tr); err != nil {
+				return fmt.Errorf("untar failed while copying data to file: %s", err.Error())
+
+			}
+			outFile.Close()
+		}
+	}
+}

--- a/internal/utils/file_utils.go
+++ b/internal/utils/file_utils.go
@@ -2,15 +2,21 @@ package utils
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// Untar expects a io.Reader with the file and a path which it will untar to
-func Untar(path string, r io.Reader) error {
+func Untar(source, destination string) error {
+	r, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
 		return err
@@ -34,7 +40,7 @@ func Untar(path string, r io.Reader) error {
 			continue
 		}
 
-		target := filepath.Join(path, header.Name)
+		target := filepath.Join(destination, header.Name)
 
 		switch header.Typeflag {
 		case tar.TypeDir:
@@ -64,4 +70,65 @@ func Untar(path string, r io.Reader) error {
 			outFile.Close()
 		}
 	}
+}
+
+func Unzip(source, destination string) error {
+	reader, err := zip.OpenReader(source)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	destination, err = filepath.Abs(destination)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range reader.File {
+		err := unzipFile(f, destination)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func unzipFile(f *zip.File, destination string) error {
+	// Check if file paths are not vulnerable to Zip Slip
+	filePath := filepath.Join(destination, f.Name)
+	if !strings.HasPrefix(filePath, filepath.Clean(destination)+string(os.PathSeparator)) {
+		return fmt.Errorf("invalid file path: %s", filePath)
+	}
+
+	// Create directory tree
+	if f.FileInfo().IsDir() {
+		if err := os.MkdirAll(filePath, os.ModePerm); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
+		return err
+	}
+
+	// Create a destination file for unzipped content
+	destinationFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+
+	// Unzip the content of a file and copy it to the destination file
+	zippedFile, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer zippedFile.Close()
+
+	if _, err := io.Copy(destinationFile, zippedFile); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?
This PR aims to add an update command. This way users will be able to update their CLI by running `lsh update`

### How
The update command will fetch the CLI release from the GitHub API and verify if the tag name matches the installed version. If there's a mismatch, the update process will start in the following order
- The release will be downloaded and untarred to a temporary folder.
- The current CLI executable will be renamed to `lsh-old`.
- The new CLI executable will be moved to the old executable path.
- The `lsh-old` executable will be removed.
- The temporary folder with the remaining files will be removed.

### How to Test
Every time we build the cli locally, the version is set to `v0.0.0`, we can take advantage of this to do this test:
- If you haven't already, install the CLI using the installation script.
- Build the CLI in the project folder by running `go build -o lsh cmd/lsh/main.go`.
- Move the newly built executable to the installation folder (usually  `~/.lsh/`).
- Run `lsh --version` and verify that it returns `lsh v0.0.0`.
- Run `lsh update`
- If everything is correct, running `lsh --version` now should return `lsh v1.0.0`, which is the latest version available at this moment.

You can also test it in the project folder by:
- Build the CLI in the project folder by running `go build -o lsh cmd/lsh/main.go`.
- Run `./lsh --version`, it should return `lsh v0.0.0`.
- Run `./lsh update`.
- Running `./lsh --version` now should return `lsh v1.0.0`.

### Working points
- [x] Handle update to folders other than `~/.lsh/`.
- [x] Linux support.
- [x] MacOs support.
- [x] Windows support.
- [ ] Implement daily messages to warn users if there's a new version available.


