### PR TITLE
Fix table rendering for virtual networks creation

### DIFF
--- a/client/virtual_networks/create_virtual_network_responses.go
+++ b/client/virtual_networks/create_virtual_network_responses.go
@@ -17,7 +17,6 @@ import (
 
 	apierrors "github.com/latitudesh/lsh/internal/api/errors"
 	"github.com/latitudesh/lsh/internal/renderer"
-	"github.com/latitudesh/lsh/models"
 )
 
 // CreateVirtualNetworkReader is a Reader for the CreateVirtualNetwork structure.
@@ -68,7 +67,7 @@ CreateVirtualNetworkCreated describes a response with status code 201, with defa
 Created
 */
 type CreateVirtualNetworkCreated struct {
-	Payload *models.VirtualNetwork
+	Payload *GetVirtualNetworkOKBody
 }
 
 // IsSuccess returns true when this create virtual network created response has a 2xx status code
@@ -109,17 +108,17 @@ func (o *CreateVirtualNetworkCreated) String() string {
 	return fmt.Sprintf("[POST /virtual_networks][%d] createVirtualNetworkCreated  %+v", 201, o.Payload)
 }
 
-func (o *CreateVirtualNetworkCreated) GetPayload() *models.VirtualNetwork {
+func (o *CreateVirtualNetworkCreated) GetPayload() *GetVirtualNetworkOKBody {
 	return o.Payload
 }
 
 func (o *CreateVirtualNetworkCreated) GetData() []renderer.ResponseData {
-	return []renderer.ResponseData{o.Payload}
+	return []renderer.ResponseData{o.Payload.Data}
 }
 
 func (o *CreateVirtualNetworkCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.VirtualNetwork)
+	o.Payload = new(GetVirtualNetworkOKBody)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {


### PR DESCRIPTION
## What

There was an issue with the table output for successful virtual network creation. The generated code didn't consider the `data` attribute in the response payload, which made the struct instance be empty and ended up breaking the table rendering.

To fix that, I changed the expected `Payload` type on the `CreateVirtualNetworkCreated`.

This was the quickest solution I found, I see some pros and cons in reusing the `GetVirtualNetworkOKBody` type:

**Pros**

- A single type to represent a virtual network payload
- Easier to add new behavior to that single type (as opposed to look for all the possible types and implement pretty much the same behavior on them)

**Cons**

- The API might have different responses for `create`, `update` and `get` actions. A single type might not fit all the responses well.

----

With that said, I think the solution on this PR is reasonable for now, but might not be the most scalable one, so we are going to have further discussions internally to decide which approach we're going to stick with.

## How to test

- Create a virtual network: `lsh virtual_networks create`
- [ ] The output should be rendered correctly