### PR TITLE
Fix response rendering for virtual network assignment

### DIFF
--- a/client/virtual_network_assignments/assign_server_virtual_network_responses.go
+++ b/client/virtual_network_assignments/assign_server_virtual_network_responses.go
@@ -77,7 +77,7 @@ AssignServerVirtualNetworkCreated describes a response with status code 201, wit
 Created
 */
 type AssignServerVirtualNetworkCreated struct {
-	Payload *models.VirtualNetworkAssignment
+	Payload *models.VirtualNetworkAssignmentPayload
 }
 
 // IsSuccess returns true when this assign server virtual network created response has a 2xx status code
@@ -118,17 +118,17 @@ func (o *AssignServerVirtualNetworkCreated) String() string {
 	return fmt.Sprintf("[POST /virtual_networks/assignments][%d] assignServerVirtualNetworkCreated  %+v", 201, o.Payload)
 }
 
-func (o *AssignServerVirtualNetworkCreated) GetPayload() *models.VirtualNetworkAssignment {
+func (o *AssignServerVirtualNetworkCreated) GetPayload() *models.VirtualNetworkAssignmentPayload {
 	return o.Payload
 }
 
 func (o *AssignServerVirtualNetworkCreated) GetData() []renderer.ResponseData {
-	return []renderer.ResponseData{o.Payload}
+	return []renderer.ResponseData{o.Payload.Data}
 }
 
 func (o *AssignServerVirtualNetworkCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.VirtualNetworkAssignment)
+	o.Payload = new(models.VirtualNetworkAssignmentPayload)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/internal/cmdflag/main.go
+++ b/internal/cmdflag/main.go
@@ -52,22 +52,24 @@ func (f *Flags) Register(s *FlagsSchema) {
 	f.Schema = s
 
 	for _, v := range *f.Schema {
+		flagName := v.FlagName()
+
 		switch v.Type {
 		case "string":
 			if defaultValue, ok := v.DefaultValue.(string); ok {
-				f.FlagSet.String(v.Name, defaultValue, v.formattedDescription())
+				f.FlagSet.String(flagName, defaultValue, v.formattedDescription())
 			}
 		case "stringSlice":
 			if defaultValue, ok := v.DefaultValue.([]string); ok {
-				f.FlagSet.StringSlice(v.Name, defaultValue, v.formattedDescription())
+				f.FlagSet.StringSlice(flagName, defaultValue, v.formattedDescription())
 			}
 		case "bool":
 			if defaultValue, ok := v.DefaultValue.(bool); ok {
-				f.FlagSet.Bool(v.Name, defaultValue, v.formattedDescription())
+				f.FlagSet.Bool(flagName, defaultValue, v.formattedDescription())
 			}
 		case "int64":
 			if defaultValue, ok := v.DefaultValue.(int64); ok {
-				f.FlagSet.Int64(v.Name, defaultValue, v.formattedDescription())
+				f.FlagSet.Int64(flagName, defaultValue, v.formattedDescription())
 			}
 		}
 	}

--- a/models/virtual_network_assignment.go
+++ b/models/virtual_network_assignment.go
@@ -12,6 +12,10 @@ import (
 	"github.com/latitudesh/lsh/internal/output/table"
 )
 
+type VirtualNetworkAssignmentPayload struct {
+	Data *VirtualNetworkAssignment `json:"data,omitempty"`
+}
+
 // VirtualNetworkAssignment virtual network assignment
 //
 // swagger:model virtual_network_assignment


### PR DESCRIPTION
The `Payload` attribute within the `AssignServerVirtualNetworkCreated` type was invalid, making the CLI crash when creating a Virtual Network Assignment. That's because we should expect a `data` attribute in the response payload, but the generated code didn't take that into account.

To fix that, I created a new type (`VirtualNetworkAssignmentPayload`) that includes a `Data` attribute.