### PR TITLE
Feat: Homebrew for distribution 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,3 +52,11 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+brews:
+  - name: lsh
+    homepage: "https://www.latitude.sh/"
+    repository:
+      owner: latitudesh
+      name: homebrew-tools
+

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ Installing the latest version
 
 #### Homebrew:
 
-
 ```
 brew install latitudesh/tools/lsh
 ```
 
-#### Instalation Script:
+#### Installation Script:
 
 ```bash
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ lsh is the [Latitude.sh](http://latitude.sh/) command-line interface that will h
 
 #### MacOS / Linux / WSL
 
-  
-
 Installing the latest version
 
-  
+#### Homebrew:
+
+
+```
+brew install latitudesh/tools/lsh
+```
+
+#### Instalation Script:
 
 ```bash
 
@@ -25,7 +30,6 @@ curl -sSL  https://raw.githubusercontent.com/latitudesh/lsh/main/install.sh | ba
 
 ```
 
-  
 
 #### Windows is not supported yet.
 


### PR DESCRIPTION
### What does this PR do?
Update our GoReleaser pipeline to automatically generate a homebrew formula and update our homebrew repository (Tap) every time we push a new version tag.

The end result will be that users will be able to install our CLI in MacOs or Linux systems using homebrew:
```
brew tap latitudesh/tools
brew install lsh
```

or for short
```
brew install latitudesh/tools/lsh
```

#### :warning: Warning
In order to merge this PR, we will need to create a repository called 'homebrew-tools' (the homebrew prefix is needed, but the 'tools' part can be changed) and set up a GitHub Personal Access Token with 'repo' and 'workflow' permissions as an Actions repository secret to be used by GoReleaser.

You can read more about the need for a github PAT here:
https://goreleaser.com/errors/resource-not-accessible-by-integration/

:heavy_check_mark: Created repository  (https://github.com/latitudesh/homebrew-tools) 
:heavy_check_mark: Token created (GORELEASER_TOKEN)

### Related resources
https://goreleaser.com/customization/homebrew/
https://docs.brew.sh/Taps
https://brew.sh/

### How to test
Testing this Pr is tricky, we can test if the goreleaser pipeline is working and generating our formula by running `goreleaser release --snapshot --skip=publish --clean` ( you will need to have goreleaser OSS installed: https://goreleaser.com/install/) 

Then verify if you have an `dist/homebrew` folder with a `lsh.rb` file inside. This file is our formula that will be used by homebrew to install our CLI