### PR TITLE
[Fix] --json flag

### DIFF
--- a/internal/utils/response_utils.go
+++ b/internal/utils/response_utils.go
@@ -26,7 +26,7 @@ func PrintError(respErr error) error {
 	case *apierrors.UnprocessableEntity:
 		output.PrintUnprocessableEntityError(e)
 	default:
-		return errors.New("An unknown error occurred.")
+		return errors.New("an unknown error occurred")
 	}
 
 	return nil
@@ -35,24 +35,19 @@ func PrintError(respErr error) error {
 func Render(data []renderer.ResponseData) {
 	var r renderer.Renderer
 
-	formatAsJSON := viper.GetBool("json")
-
-	if formatAsJSON {
-		r = renderer.JSONRenderer{}
-	}
-
 	formatOutputFlag := viper.GetString("output")
 
-	switch formatOutputFlag {
-	case "json":
+	switch {
+	case viper.GetBool("json"):
 		r = renderer.JSONRenderer{}
-	case "table":
+	case formatOutputFlag == "json":
+		r = renderer.JSONRenderer{}
+	case formatOutputFlag == "table":
 		r = renderer.TableRenderer{}
 	default:
 		fmt.Println("Unsupported output format")
 	}
 
 	renderContext := renderer.NewRenderContext(r)
-
 	renderContext.Render(data)
 }

--- a/internal/utils/response_utils.go
+++ b/internal/utils/response_utils.go
@@ -4,6 +4,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	apierrors "github.com/latitudesh/lsh/internal/api/errors"
 	"github.com/latitudesh/lsh/internal/output"
@@ -45,7 +46,8 @@ func Render(data []renderer.ResponseData) {
 	case formatOutputFlag == "table":
 		r = renderer.TableRenderer{}
 	default:
-		fmt.Println("Unsupported output format")
+		fmt.Printf("\nUnsupported output format\n\n")
+		os.Exit(1)
 	}
 
 	renderContext := renderer.NewRenderContext(r)


### PR DESCRIPTION
## What

The `--json` flag is being accepted but it's not returning the output formatted as JSON. This happens due to an wrong reassignment of the render. This PR fixes that reassignment but placing all the conditions in a single switch/case statement.

## How to test

- Run a command without passing any formatting flags
- [ ] It should return the response as a table
- [ ] When passing `--output json` it should format the response as JSON
- [ ] When passing `--output table` it should format the response as table
- [ ] When passing `--json` it should format the response as JSON
- [ ] When passing an invalid output option (like `--output html`), it should display this message and exit the CLI: `Unsupported output format`