### PR TITLE
Feat: uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ lsh plans list --gpu true
 You can see more examples [here](https://docs.latitude.sh/docs/examples-1). Reach out if you want to see other use cases on `lsh`.
   
 
+## Troubleshooting
+If you encounter any problems when installing the CLI with the installation script, you can use the command below to uninstall the CLI.
+
+```bash
+
+curl -sSL  https://raw.githubusercontent.com/latitudesh/lsh/main/uninstall.sh | bash
+
+```
+
 ## Docs
 
   

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,31 +12,31 @@ echo -e "Removing $INSTALL_DIR from PATH\n";
 
 if echo $PATH | grep -q $INSTALL_DIR 
 then
+NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||g');
 case "$SHELL_NAME" in
     "bash")
         SHELL_CONFIG_PATH=~/.bashrc
-        NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||');
         echo "export PATH=$NEW_PATH" >> $SHELL_CONFIG_PATH;
         ;;
     "zsh")
         SHELL_CONFIG_PATH=~/.zshrc
-        NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||')
         echo "export PATH=$NEW_PATH" >> $SHELL_CONFIG_PATH
         ;;
     "fish")
         SHELL_CONFIG_PATH=~/.config/fish/config.fish
-        NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||')
         echo 'set -gx PATH $NEW_PATH' >> $SHELL_CONFIG_PATH
         ;;
     *)
         echo "Unsupported shell: $SHELL_NAME, you will need to set your PATH manually\n"
         ;;
 esac
-else
-    echo -e "lsh executable not in PATH\n"
-fi
 
 echo -e "Deleting $INSTALL_DIR\n";
 rm -dr $INSTALL_DIR;
 
-echo -e "Uninstall finished successfully\n"
+echo -e "Uninstall finished successfully\nrun: \n"
+echo -e "    source $SHELL_CONFIG_PATH\n"
+echo -e "to apply changes to your current session"
+else
+    echo -e "lsh executable not found!\n"
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+echo -e "[lsh] Uninstalling the CLI from your system\n"
+HOME_DIR=$(echo ~)
+INSTALL_DIR="$HOME_DIR/.lsh"
+mkdir -p $INSTALL_DIR
+
+# Detect the current shell and add the directory to the user's PATH
+SHELL_NAME=$(basename "$SHELL")
+SHELL_CONFIG_PATH=""
+echo -e "Removing $INSTALL_DIR from PATH\n";
+
+if echo $PATH | grep -q $INSTALL_DIR 
+then
+case "$SHELL_NAME" in
+    "bash")
+        SHELL_CONFIG_PATH=~/.bashrc
+        NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||');
+        echo "export PATH=$NEW_PATH" >> $SHELL_CONFIG_PATH;
+        ;;
+    "zsh")
+        SHELL_CONFIG_PATH=~/.zshrc
+        NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||')
+        echo "export PATH=$NEW_PATH" >> $SHELL_CONFIG_PATH
+        ;;
+    "fish")
+        SHELL_CONFIG_PATH=~/.config/fish/config.fish
+        NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||')
+        echo 'set -gx PATH $NEW_PATH' >> $SHELL_CONFIG_PATH
+        ;;
+    *)
+        echo "Unsupported shell: $SHELL_NAME, you will need to set your PATH manually\n"
+        ;;
+esac
+else
+    echo -e "lsh executable not in PATH\n"
+fi
+
+echo -e "Deleting $INSTALL_DIR\n";
+rm -dr $INSTALL_DIR;
+
+echo -e "Uninstall finished successfully\n"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,11 +8,11 @@ mkdir -p $INSTALL_DIR
 # Detect the current shell and add the directory to the user's PATH
 SHELL_NAME=$(basename "$SHELL")
 SHELL_CONFIG_PATH=""
-echo -e "Removing $INSTALL_DIR from PATH\n";
+echo -e "Removing $INSTALL_DIR from PATH\n"
 
 if echo $PATH | grep -q $INSTALL_DIR 
 then
-NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||g');
+NEW_PATH=$(echo $PATH | sed 's|:'$HOME_DIR/.lsh'||g')
 case "$SHELL_NAME" in
     "bash")
         SHELL_CONFIG_PATH=~/.bashrc
@@ -31,8 +31,8 @@ case "$SHELL_NAME" in
         ;;
 esac
 
-echo -e "Deleting $INSTALL_DIR\n";
-rm -dr $INSTALL_DIR;
+echo -e "Deleting $INSTALL_DIR\n"
+rm -dr $INSTALL_DIR
 
 echo -e "Uninstall finished successfully\nrun: \n"
 echo -e "    source $SHELL_CONFIG_PATH\n"


### PR DESCRIPTION
### What does this PR do?
Some users who installed the CLI with the install script might run into some issues when migrating to Homebrew. This PR introduces an `uninstall.sh` script that that reverts the `install.sh` script actions.

### Testing this PR
To test the script you'll need to have `lsh` installed with the install script, if you haven't already you can grab it with:
```
curl -sSL  https://raw.githubusercontent.com/latitudesh/lsh/main/install.sh | bash
```
After following the instructions you should have :<$HOME_DIR>/.lsh at the end of your path variable, and a .lsh folder in your home directory, you can verify it with:
```
# Printing your path variable
echo $PATH

# Checking if the directory exists
ls ~/.lsh 
```
Run the uninstall script:
```
curl -sSL https://raw.githubusercontent.com/latitudesh/lsh/758136ffcf44d4e39fbc265a6891596df4e9cc7a/uninstall.sh | bash
```
Verify that :<$HOME_DIR>/.lsh got erased from your path variable and that the `~/.lsh` folder shouldn't exist anymore.

### Verified Shells:
- [x] bash
- [x] zsh
- [ ] fish
