### PR TITLE
fix: project flag missing from commands

### DIFF
--- a/cli/create_server_operation.go
+++ b/cli/create_server_operation.go
@@ -103,6 +103,12 @@ func (o *CreateServerOperation) registerFlags(cmd *cobra.Command) {
 			Description: "User data to set on the server",
 			Required:    false,
 		},
+		&cmdflag.String{
+			Name:        "project",
+			Label:       "Project",
+			Description: "The project (ID or Slug) to deploy the server",
+			Required:    true,
+		},
 	}
 
 	o.BodyAttributesFlags.Register(schema)
@@ -110,16 +116,7 @@ func (o *CreateServerOperation) registerFlags(cmd *cobra.Command) {
 
 func (o *CreateServerOperation) preRun(cmd *cobra.Command, args []string) {
 	projects := fetchUserProjects()
-	schema := &cmdflag.FlagsSchema{
-		&cmdflag.String{
-			Name:        "project",
-			Label:       "Project",
-			Description: "The project (ID or Slug) to deploy the server",
-			Required:    true,
-			Options:     projects,
-		},
-	}
-	o.BodyAttributesFlags.AppendFlags(schema)
+	o.BodyAttributesFlags.AddFlagOption("project", projects)
 
 	o.BodyAttributesFlags.PreRun(cmd, args)
 }

--- a/cli/create_virtual_network_operation.go
+++ b/cli/create_virtual_network_operation.go
@@ -57,6 +57,12 @@ func (o *CreateVirtualNetworkOperation) registerFlags(cmd *cobra.Command) {
 			Options:     virtualNetwork.SupportedSites,
 			Required:    false,
 		},
+		&cmdflag.String{
+			Name:        "project",
+			Label:       "Project ID or Slug",
+			Description: "Project ID or Slug",
+			Required:    true,
+		},
 	}
 
 	o.BodyAttributesFlags.Register(schema)
@@ -64,16 +70,7 @@ func (o *CreateVirtualNetworkOperation) registerFlags(cmd *cobra.Command) {
 
 func (o *CreateVirtualNetworkOperation) preRun(cmd *cobra.Command, args []string) {
 	projects := fetchUserProjects()
-	schema := &cmdflag.FlagsSchema{
-		&cmdflag.String{
-			Name:        "project",
-			Label:       "Project ID or Slug",
-			Description: "Project ID or Slug",
-			Required:    true,
-			Options:     projects,
-		},
-	}
-	o.BodyAttributesFlags.AppendFlags(schema)
+	o.BodyAttributesFlags.AddFlagOption("project", projects)
 
 	o.BodyAttributesFlags.PreRun(cmd, args)
 }

--- a/cli/delete_project_ssh_key_operation.go
+++ b/cli/delete_project_ssh_key_operation.go
@@ -48,6 +48,12 @@ func (o *DeleteSSHKeyOperation) registerFlags(cmd *cobra.Command) {
 			Description: "ID from the SSH Key you want to update",
 			Required:    true,
 		},
+		&cmdflag.String{
+			Name:        "project",
+			Label:       "Project ID or Slug",
+			Description: "Project ID or Slug",
+			Required:    true,
+		},
 	}
 
 	o.PathParamFlags.Register(schema)
@@ -55,16 +61,7 @@ func (o *DeleteSSHKeyOperation) registerFlags(cmd *cobra.Command) {
 
 func (o *DeleteSSHKeyOperation) preRun(cmd *cobra.Command, args []string) {
 	projects := fetchUserProjects()
-	schema := &cmdflag.FlagsSchema{
-		&cmdflag.String{
-			Name:        "project",
-			Label:       "Project ID or Slug",
-			Description: "Project ID or Slug",
-			Required:    true,
-			Options:     projects,
-		},
-	}
-	o.PathParamFlags.AppendFlags(schema)
+	o.PathParamFlags.AddFlagOption("project", projects)
 
 	o.PathParamFlags.PreRun(cmd, args)
 }

--- a/cli/post_project_ssh_key_operation.go
+++ b/cli/post_project_ssh_key_operation.go
@@ -43,7 +43,13 @@ func (o *CreateSSHKeyOperation) registerFlags(cmd *cobra.Command) {
 	o.PathParamFlags = cmdflag.Flags{FlagSet: cmd.Flags()}
 	o.BodyAttributesFlags = cmdflag.Flags{FlagSet: cmd.Flags()}
 
-	pathParamsSchema := &cmdflag.FlagsSchema{}
+	pathParamsSchema := &cmdflag.FlagsSchema{
+		&cmdflag.String{
+			Name:        "project",
+			Label:       "Project ID or Slug",
+			Description: "Project ID or Slug",
+			Required:    true,
+		}}
 
 	bodyFlagsSchema := &cmdflag.FlagsSchema{
 		&cmdflag.String{
@@ -66,16 +72,7 @@ func (o *CreateSSHKeyOperation) registerFlags(cmd *cobra.Command) {
 
 func (o *CreateSSHKeyOperation) preRun(cmd *cobra.Command, args []string) {
 	projects := fetchUserProjects()
-	schema := &cmdflag.FlagsSchema{
-		&cmdflag.String{
-			Name:        "project",
-			Label:       "ID or Slug from the project you want to add the SSH Key",
-			Description: "ID or Slug from the project you want to add the SSH Key",
-			Required:    true,
-			Options:     projects,
-		},
-	}
-	o.PathParamFlags.AppendFlags(schema)
+	o.PathParamFlags.AddFlagOption("project", projects)
 
 	o.PathParamFlags.PreRun(cmd, args)
 	o.BodyAttributesFlags.PreRun(cmd, args)

--- a/cli/put_project_ssh_key_operation.go
+++ b/cli/put_project_ssh_key_operation.go
@@ -50,6 +50,12 @@ func (o *UpdateSSHKeyOperation) registerFlags(cmd *cobra.Command) {
 			Description: "ID from the SSH Key you want to update",
 			Required:    true,
 		},
+		&cmdflag.String{
+			Name:        "project",
+			Label:       "Project ID or Slug",
+			Description: "Project ID or Slug",
+			Required:    true,
+		},
 	}
 
 	bodyFlagsSchema := &cmdflag.FlagsSchema{
@@ -73,16 +79,7 @@ func (o *UpdateSSHKeyOperation) registerFlags(cmd *cobra.Command) {
 
 func (o *UpdateSSHKeyOperation) preRun(cmd *cobra.Command, args []string) {
 	projects := fetchUserProjects()
-	schema := &cmdflag.FlagsSchema{
-		&cmdflag.String{
-			Name:        "project",
-			Label:       "Project ID or Slug",
-			Description: "Project ID or Slug",
-			Required:    true,
-			Options:     projects,
-		},
-	}
-	o.PathParamFlags.AppendFlags(schema)
+	o.PathParamFlags.AddFlagOption("project", projects)
 
 	o.PathParamFlags.PreRun(cmd, args)
 	o.BodyAttributesFlags.PreRun(cmd, args)

--- a/internal/cmdflag/bool.go
+++ b/internal/cmdflag/bool.go
@@ -51,3 +51,7 @@ func (f *Bool) description() string {
 
 	return fmt.Sprintf("[Required] %v", f.Description)
 }
+
+func (f *Bool) UpdateOptions(options interface{}) {
+	//Function needed to implement interface
+}

--- a/internal/cmdflag/int64.go
+++ b/internal/cmdflag/int64.go
@@ -51,3 +51,7 @@ func (f *Int64) description() string {
 
 	return fmt.Sprintf("[Required] %v", f.Description)
 }
+
+func (f *Int64) UpdateOptions(options interface{}) {
+	//Function needed to implement interface
+}

--- a/internal/cmdflag/main.go
+++ b/internal/cmdflag/main.go
@@ -13,6 +13,7 @@ import (
 
 type FlagSchema interface {
 	Register(f *pflag.FlagSet)
+	UpdateOptions(options interface{})
 	GetValue() interface{}
 	GetName() string
 	Prompt() prompt.PromptInput
@@ -35,11 +36,11 @@ func (f *Flags) Register(s *FlagsSchema) {
 	}
 }
 
-func (f *Flags) AppendFlags(s *FlagsSchema) {
-	*f.schema = append(*f.schema, *s...)
-
-	for _, v := range *s {
-		v.Register(f.FlagSet)
+func (f *Flags) AddFlagOption(flagName string, option []string) {
+	for _, flag := range *f.schema {
+		if flag.GetName() == flagName {
+			flag.UpdateOptions(option)
+		}
 	}
 }
 

--- a/internal/cmdflag/string.go
+++ b/internal/cmdflag/string.go
@@ -57,3 +57,8 @@ func (f *String) description() string {
 
 	return fmt.Sprintf("[Required] %v", f.Description)
 }
+
+func (f *String) UpdateOptions(options interface{}) {
+	option := options.([]string)
+	f.Options = append(f.Options, option...)
+}

--- a/internal/cmdflag/string_slice.go
+++ b/internal/cmdflag/string_slice.go
@@ -51,3 +51,7 @@ func (f *StringSlice) description() string {
 
 	return fmt.Sprintf("[Required] %v", f.Description)
 }
+
+func (f *StringSlice) UpdateOptions(options interface{}) {
+	//Function needed to implement interface
+}


### PR DESCRIPTION
## What does this PR do?
Fixes a bug with the project flag.
When we introduced the project selection, it stoped letting users send it with `--project`.

## How
We were setting the project flag in the preRun function of the command, so the flag wasn't defined until the command was used. Now, the flag is set normally with all the others. The options list, which is used for the selection, is populated in the preRun function.

## How to test
The project parameter should be accessible both by using the `--project` flag, or with a selection menu that will appear automatically when not passing the flag.

Build the CLI
```
go build -o lsh
```
Test the following commands with and without the `--project` flag.

```
./lsh servers create
```

```
./lsh ssh_keys create
```

```
./lsh ssh_keys update
```

```
./lsh ssh_keys destroy
```

