### PR TITLE
Fix immediate expansion of PATH variable in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,11 +33,11 @@ SHELL_CONFIG_PATH=""
 case "$SHELL_NAME" in
     "bash")
         SHELL_CONFIG_PATH=~/.bashrc
-        echo "export PATH=$PATH:$HOME_DIR/.lsh" >> $SHELL_CONFIG_PATH
+        echo 'export PATH="$PATH:$HOME/.lsh"' >> $SHELL_CONFIG_PATH
         ;;
     "zsh")
         SHELL_CONFIG_PATH=~/.zshrc
-        echo "export PATH=$PATH:$HOME_DIR/.lsh" >> $SHELL_CONFIG_PATH
+        echo 'export PATH="$PATH:$HOME/.lsh"' >> $SHELL_CONFIG_PATH
         ;;
     "fish")
         SHELL_CONFIG_PATH=~/.config/fish/config.fish


### PR DESCRIPTION
**Description**: This pull request addresses an issue in the install.sh script where the $PATH variable was being expanded immediately during the script's execution. This was found in two instances within the script, potentially causing erroneous PATH configurations by embedding a static and incomplete PATH at the time of installation.

**Changes**:

- Updated all instances where the PATH is appended with $HOME_DIR/.lsh to use single quotes and $HOME, ensuring that the PATH variable is written as a shell-expandable string, preserving its dynamic nature and preventing issues across different user environments and shell sessions.

